### PR TITLE
Enhancement/ansible playbook offline snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
  * add command export-packages
  * add polling state of the sent command
  * add ansible module to output the log of the sent command to stdout
+ * add ansible playbook for offline-snapshot and offline-compaction-snapshot
 
 
 ### 1.1.0
@@ -12,4 +13,3 @@
 
 ### 1.0.0
 * Initial version
-

--- a/Makefile
+++ b/Makefile
@@ -48,10 +48,10 @@ import-package:
 	./send-message.sh "$(stack_prefix)" "$(topic_config_file)" "$(message_config_file)" "component=$(component) source_stack_prefix=$(source_stack_prefix) package_group=$(package_group) package_name=$(package_name) package_datestamp=$(package_datestamp)"
 
 offline-snapshot:
-	./send-message.sh "$(stack_prefix)" "$(topic_config_file)" "$(message_config_file)"
+	./offline-snapshot.sh "$(stack_prefix)" "$(topic_config_file)" "$(message_config_file)"
 
 offline-compaction-snapshot:
-	./send-message.sh "$(stack_prefix)" "$(topic_config_file)" "$(message_config_file)"
+	./offline-compaction-snapshot.sh "$(stack_prefix)" "$(topic_config_file)" "$(message_config_file)"
 
 
 package:

--- a/ansible/library/log_output.py
+++ b/ansible/library/log_output.py
@@ -105,7 +105,7 @@ def main():
 
     result = log.analyse()
 
-    module.exit_json(changed=True, item=result)
+    module.exit_json(changed=True, msg=result)
 
 if __name__ == '__main__':
     main()

--- a/examples/all.yaml
+++ b/examples/all.yaml
@@ -1,0 +1,7 @@
+---
+aws_region: ap-southeast-2
+dynamodb_tablename: aem-stack-manager-AemStackManagerTable
+sns_topic: arn:aws:sns:ap-southeast-2:0123456789:aem-stack-manager-AemStackManager
+stackmanager_prefix: aem-stack-manager
+s3:
+  bucket: aem-stack-manager

--- a/examples/backup.yaml
+++ b/examples/backup.yaml
@@ -1,0 +1,7 @@
+---
+aws_region: ap-southeast-2
+dynamodb_tablename: aem-stack-manager-AemStackManagerTable
+sns_topic: arn:aws:sns:ap-southeast-2:0123456789:aem-stack-manager-AemOfflineBackup
+stackmanager_prefix: aem-stack-manager
+s3:
+  bucket: aem-stack-manager

--- a/offline-compaction-snapshot.sh
+++ b/offline-compaction-snapshot.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -o errexit
+
+run_id=${RUN_ID:-$(date +%Y-%m-%d:%H:%M:%S)}
+log_path=logs/$run_id-send-message.log
+
+# Construct Ansible extra_vars flags.
+# If CONFIG_FILE is set, values will be added.
+
+extra_vars=(--extra-vars "stack_prefix=$stack_prefix")
+
+# shellcheck disable=SC2154
+extra_vars+=(--extra-vars "@$topic_config_file")
+
+# shellcheck disable=SC2154
+extra_vars+=(--extra-vars "@$message_config_file")
+
+if [ ! -z "$4" ]; then
+    extra_vars+=(--extra-vars "$4")
+fi
+
+mkdir -p logs
+echo "Sending Message SNS Topic"
+ANSIBLE_LOG_PATH=$log_path \
+  ansible-playbook offline-compaction-snapshot.yaml \
+  -v \
+  -i ansible/inventory/hosts \
+  --module-path ansible/library/ \
+  "${extra_vars[@]}"
+echo "Finished Sending Message to SNS Topic"

--- a/offline-compaction-snapshot.yaml
+++ b/offline-compaction-snapshot.yaml
@@ -1,0 +1,309 @@
+---
+- name: SNS Message Sender
+  hosts: all
+  gather_facts: no
+  connection: local
+
+  vars:
+    message_file:
+# files are in .txt as they need to replace the variables e.g. 'stack_prefix' (un-quoted) which breaks the json validation.
+# if the variables were in double quotes, they would not be replaced with the value.
+    message: "{{ lookup('file', message_file) }}"
+
+  tasks:
+
+    - debug:
+        msg: "Send message: {{ message }} with subject: {{ subject }} to topic: {{ sns_topic }} in region: {{ aws_region }}"
+
+    - name: Send message to SNS Topic
+      sns:
+        msg: "{{ message }}"
+        subject: "{{ subject }}"
+        topic: "{{ sns_topic }}"
+        region: "{{ aws_region }}"
+      register: publish_message
+
+    - name: Scan if author standby instance is stopped
+      dynamodb_search:
+        table_name: "{{ dynamodb_tablename }}"
+        attribute: message_id
+        attribute_value: "{{ publish_message.item.PublishResponse.PublishResult.MessageId }}"
+        get_attribute: command_id
+        select: SPECIFIC_ATTRIBUTES
+        comparisonoperator: EQ
+        state: scan
+      register: cmd_stop_author_standby
+      until: cmd_stop_author_standby.item != []
+      retries: 120
+      delay: 5
+
+    - set_fact:
+        cmd_id: "{{ item.command_id.S }}"
+      with_items:
+        "{{ cmd_stop_author_standby.item }}"
+
+    - name: Scan if author primary instance is stopped
+      dynamodb_search:
+        table_name: "{{ dynamodb_tablename }}"
+        attribute: last_command
+        attribute_value: "{{ cmd_id }}"
+        get_attribute: command_id
+        select: SPECIFIC_ATTRIBUTES
+        comparisonoperator: EQ
+        state: scan
+      register: cmd_stop_author_primary
+      until: cmd_stop_author_primary.item != []
+      retries: 120
+      delay: 5
+
+    - set_fact:
+        cmd_id: "{{ item.command_id.S }}"
+      with_items:
+        "{{ cmd_stop_author_primary.item }}"
+
+    - name: Scan if publish instance is stopped
+      dynamodb_search:
+        table_name: "{{ dynamodb_tablename }}"
+        attribute: last_command
+        attribute_value: "{{ cmd_id }}"
+        get_attribute: command_id
+        select: SPECIFIC_ATTRIBUTES
+        comparisonoperator: EQ
+        state: scan
+      register: cmd_stop_publish
+      until: cmd_stop_publish.item != []
+      retries: 120
+      delay: 5
+
+    - set_fact:
+        cmd_id: "{{ item.command_id.S }}"
+      with_items:
+        "{{ cmd_stop_publish.item }}"
+
+    - name: Scan if offline-compaction finished
+      dynamodb_search:
+        table_name: "{{ dynamodb_tablename }}"
+        attribute: last_command
+        attribute_value: "{{ cmd_id }}"
+        get_attribute: command_id
+        select: SPECIFIC_ATTRIBUTES
+        comparisonoperator: EQ
+        state: scan
+      register: cmd_offline_compaction
+      until: cmd_offline_compaction.item != []
+      retries: 120
+      delay: 5
+
+    - set_fact:
+        cmd_id: "{{ item.command_id.S }}"
+      with_items:
+        "{{ cmd_offline_compaction.item }}"
+
+    - name: Scan if offline-backup is executed
+      dynamodb_search:
+        table_name: "{{ dynamodb_tablename }}"
+        attribute: last_command
+        attribute_value: "{{ cmd_id }}"
+        get_attribute: command_id
+        select: SPECIFIC_ATTRIBUTES
+        comparisonoperator: EQ
+        state: scan
+      register: cmd_offline_backup
+      until: cmd_offline_backup.item != []
+      retries: 120
+      delay: 5
+
+    - set_fact:
+        cmd_id: "{{ item.command_id.S }}"
+      with_items:
+        "{{ cmd_offline_backup.item }}"
+
+    - name: Scan if author primary instance is started
+      dynamodb_search:
+        table_name: "{{ dynamodb_tablename }}"
+        attribute: last_command
+        attribute_value: "{{ cmd_id }}"
+        get_attribute: command_id
+        select: SPECIFIC_ATTRIBUTES
+        comparisonoperator: EQ
+        state: scan
+      register: cmd_start_author_primary
+      until: cmd_start_author_primary.item != []
+      retries: 120
+      delay: 5
+
+    - set_fact:
+        cmd_id: "{{ item.command_id.S }}"
+      with_items:
+        "{{ cmd_start_author_primary.item }}"
+
+    - name: Scan if author standby instance is started
+      dynamodb_search:
+        table_name: "{{ dynamodb_tablename }}"
+        attribute: last_command
+        attribute_value: "{{ cmd_id }}"
+        get_attribute: command_id
+        select: SPECIFIC_ATTRIBUTES
+        comparisonoperator: EQ
+        state: scan
+      register: cmd_start_author_standby
+      until: cmd_start_author_standby.item != []
+      retries: 120
+      delay: 5
+
+    - set_fact:
+        cmd_id: "{{ item.command_id.S }}"
+      with_items:
+        "{{ cmd_start_author_standby.item }}"
+
+    - name: Scan if publish instance is started
+      dynamodb_search:
+        table_name: "{{ dynamodb_tablename }}"
+        attribute: last_command
+        attribute_value: "{{ cmd_id }}"
+        get_attribute: command_id
+        select: SPECIFIC_ATTRIBUTES
+        comparisonoperator: EQ
+        state: scan
+      register: cmd_start_publish
+      until: cmd_start_publish.item != []
+      retries: 120
+      delay: 5
+
+    - set_fact:
+        cmd_id: "{{ item.command_id.S }}"
+      with_items:
+        "{{ cmd_start_publish.item }}"
+
+    - name: Scan if job compact_remaining_publish is finished
+      dynamodb_search:
+        table_name: "{{ dynamodb_tablename }}"
+        attribute: last_command
+        attribute_value: "{{ cmd_id }}"
+        get_attribute: command_id
+        select: SPECIFIC_ATTRIBUTES
+        comparisonoperator: EQ
+        state: scan
+      register: cmd_remaining_compact_jobs
+      until: cmd_remaining_compact_jobs.item != []
+      retries: 120
+      delay: 5
+
+    - set_fact:
+        cmd_id: "{{ item.command_id.S }}"
+      with_items:
+        "{{ cmd_remaining_compact_jobs.item }}"
+
+    - name: Scan if remaining publish instances are stopped
+      dynamodb_search:
+        table_name: "{{ dynamodb_tablename }}"
+        attribute: last_command
+        attribute_value: "{{ cmd_id }}"
+        get_attribute: command_id
+        select: SPECIFIC_ATTRIBUTES
+        comparisonoperator: EQ
+        state: scan
+      register: cmd_stop_publish
+      until: cmd_stop_publish.item != []
+      retries: 120
+      delay: 5
+
+    - set_fact:
+        cmd_id: "{{ item.command_id.S }}"
+      with_items:
+        "{{ cmd_stop_publish.item }}"
+
+    - name: Scan if remaining publish instances are compacted
+      dynamodb_search:
+        table_name: "{{ dynamodb_tablename }}"
+        attribute: last_command
+        attribute_value: "{{ cmd_id }}"
+        get_attribute: command_id
+        select: SPECIFIC_ATTRIBUTES
+        comparisonoperator: EQ
+        state: scan
+      register: cmd_compact_publish
+      until: cmd_compact_publish.item != []
+      retries: 120
+      delay: 5
+
+    - set_fact:
+        cmd_id: "{{ item.command_id.S }}"
+      with_items:
+        "{{ cmd_compact_publish.item }}"
+
+    - name: Scan if remaining publish instances are started
+      dynamodb_search:
+        table_name: "{{ dynamodb_tablename }}"
+        attribute: last_command
+        attribute_value: "{{ cmd_id }}"
+        get_attribute: command_id
+        select: SPECIFIC_ATTRIBUTES
+        comparisonoperator: EQ
+        state: scan
+      register: cmd_start_publish
+      until: cmd_start_publish.item != []
+      retries: 120
+      delay: 5
+
+    - set_fact:
+        cmd_id: "{{ item.command_id.S }}"
+      with_items:
+        "{{ cmd_start_publish.item }}"
+
+    - name: Query if offline-compaction-snapshot was successful
+      dynamodb_search:
+        table_name: "{{ dynamodb_tablename }}"
+        attribute: command_id
+        attribute_value: "{{ cmd_id }}"
+        get_attribute: state
+        select: SPECIFIC_ATTRIBUTES
+        comparisonoperator: EQ
+        state: query
+      register: dbquery
+      until: dbquery.item[0].state.S == "Success" or dbquery.item[0].state.S == "Failed"
+      # The retry values should mirror the TTL of the ssm.send_command of the Lambda function.
+      retries: 120
+      delay: 5
+
+    - name: Get path to output files
+      aws_s3:
+        mode: list
+        bucket: "{{ s3.bucket }}"
+        prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id }}"
+      register: output_files
+
+    - name: Set facts for getting command output
+      set_fact:
+        log_path: "{{ playbook_dir }}/logs/"
+        dl_path: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id }}"
+        s3_files: "{{ output_files.s3_keys }}"
+
+    - name: "Create Download directory in {{log_path }}{{ dl_path }}"
+      file:
+        path: "{{ log_path }}{{ item|regex_replace('(stdout|stderr)$', '') }}"
+        state: directory
+      with_items:
+        - "{{ s3_files }}"
+
+    - name: "Save command output to {{log_path }}{{ dl_path }}"
+      aws_s3:
+        mode: get
+        bucket: "{{ s3.bucket }}"
+        object: "{{ item }}"
+        dest: "{{ log_path }}{{ item }}"
+      with_items:
+        - "{{ s3_files }}"
+      register: saved_files
+
+    - name: "Find error log files in {{log_path }}{{ dl_path }}"
+      find:
+        paths: "{{log_path }}{{ dl_path }}"
+        file_type: file
+        patterns: stderr
+        recurse: yes
+      register: stderr_files
+
+    - log_output:
+        type: file
+        log_files: "{{ stderr_files.files | map(attribute='path')|list }}"

--- a/offline-compaction-snapshot.yaml
+++ b/offline-compaction-snapshot.yaml
@@ -34,11 +34,11 @@
         state: scan
       register: cmd_stop_author_standby
       until: cmd_stop_author_standby.item != []
-      retries: 120
+      retries:  720
       delay: 5
 
     - set_fact:
-        cmd_id: "{{ item.command_id.S }}"
+        cmd_id_stop_author_standby: "{{ item.command_id.S }}"
       with_items:
         "{{ cmd_stop_author_standby.item }}"
 
@@ -46,18 +46,18 @@
       dynamodb_search:
         table_name: "{{ dynamodb_tablename }}"
         attribute: last_command
-        attribute_value: "{{ cmd_id }}"
+        attribute_value: "{{ cmd_id_stop_author_standby }}"
         get_attribute: command_id
         select: SPECIFIC_ATTRIBUTES
         comparisonoperator: EQ
         state: scan
       register: cmd_stop_author_primary
       until: cmd_stop_author_primary.item != []
-      retries: 120
+      retries:  720
       delay: 5
 
     - set_fact:
-        cmd_id: "{{ item.command_id.S }}"
+        cmd_id_stop_author_primary: "{{ item.command_id.S }}"
       with_items:
         "{{ cmd_stop_author_primary.item }}"
 
@@ -65,18 +65,18 @@
       dynamodb_search:
         table_name: "{{ dynamodb_tablename }}"
         attribute: last_command
-        attribute_value: "{{ cmd_id }}"
+        attribute_value: "{{ cmd_id_stop_author_primary }}"
         get_attribute: command_id
         select: SPECIFIC_ATTRIBUTES
         comparisonoperator: EQ
         state: scan
       register: cmd_stop_publish
       until: cmd_stop_publish.item != []
-      retries: 120
+      retries:  720
       delay: 5
 
     - set_fact:
-        cmd_id: "{{ item.command_id.S }}"
+        cmd_id_stop_publish: "{{ item.command_id.S }}"
       with_items:
         "{{ cmd_stop_publish.item }}"
 
@@ -84,18 +84,18 @@
       dynamodb_search:
         table_name: "{{ dynamodb_tablename }}"
         attribute: last_command
-        attribute_value: "{{ cmd_id }}"
+        attribute_value: "{{ cmd_id_stop_publish }}"
         get_attribute: command_id
         select: SPECIFIC_ATTRIBUTES
         comparisonoperator: EQ
         state: scan
       register: cmd_offline_compaction
       until: cmd_offline_compaction.item != []
-      retries: 120
+      retries:  720
       delay: 5
 
     - set_fact:
-        cmd_id: "{{ item.command_id.S }}"
+        cmd_id_offline_compaction: "{{ item.command_id.S }}"
       with_items:
         "{{ cmd_offline_compaction.item }}"
 
@@ -103,18 +103,18 @@
       dynamodb_search:
         table_name: "{{ dynamodb_tablename }}"
         attribute: last_command
-        attribute_value: "{{ cmd_id }}"
+        attribute_value: "{{ cmd_id_offline_compaction }}"
         get_attribute: command_id
         select: SPECIFIC_ATTRIBUTES
         comparisonoperator: EQ
         state: scan
       register: cmd_offline_backup
       until: cmd_offline_backup.item != []
-      retries: 120
+      retries:  720
       delay: 5
 
     - set_fact:
-        cmd_id: "{{ item.command_id.S }}"
+        cmd_id_offline_backup: "{{ item.command_id.S }}"
       with_items:
         "{{ cmd_offline_backup.item }}"
 
@@ -122,18 +122,18 @@
       dynamodb_search:
         table_name: "{{ dynamodb_tablename }}"
         attribute: last_command
-        attribute_value: "{{ cmd_id }}"
+        attribute_value: "{{ cmd_id_offline_backup }}"
         get_attribute: command_id
         select: SPECIFIC_ATTRIBUTES
         comparisonoperator: EQ
         state: scan
       register: cmd_start_author_primary
       until: cmd_start_author_primary.item != []
-      retries: 120
+      retries:  720
       delay: 5
 
     - set_fact:
-        cmd_id: "{{ item.command_id.S }}"
+        cmd_id_start_author_primary: "{{ item.command_id.S }}"
       with_items:
         "{{ cmd_start_author_primary.item }}"
 
@@ -141,18 +141,18 @@
       dynamodb_search:
         table_name: "{{ dynamodb_tablename }}"
         attribute: last_command
-        attribute_value: "{{ cmd_id }}"
+        attribute_value: "{{ cmd_id_start_author_primary }}"
         get_attribute: command_id
         select: SPECIFIC_ATTRIBUTES
         comparisonoperator: EQ
         state: scan
       register: cmd_start_author_standby
       until: cmd_start_author_standby.item != []
-      retries: 120
+      retries:  720
       delay: 5
 
     - set_fact:
-        cmd_id: "{{ item.command_id.S }}"
+        cmd_id_start_author_standby: "{{ item.command_id.S }}"
       with_items:
         "{{ cmd_start_author_standby.item }}"
 
@@ -160,75 +160,75 @@
       dynamodb_search:
         table_name: "{{ dynamodb_tablename }}"
         attribute: last_command
-        attribute_value: "{{ cmd_id }}"
+        attribute_value: "{{ cmd_id_start_author_standby }}"
         get_attribute: command_id
         select: SPECIFIC_ATTRIBUTES
         comparisonoperator: EQ
         state: scan
       register: cmd_start_publish
       until: cmd_start_publish.item != []
-      retries: 120
+      retries:  720
       delay: 5
 
     - set_fact:
-        cmd_id: "{{ item.command_id.S }}"
+        cmd_id_start_publish: "{{ item.command_id.S }}"
       with_items:
         "{{ cmd_start_publish.item }}"
 
-    - name: Scan if job compact_remaining_publish is finished
+    - name: Scan if job remaining compact jobs are finished
       dynamodb_search:
         table_name: "{{ dynamodb_tablename }}"
         attribute: last_command
-        attribute_value: "{{ cmd_id }}"
+        attribute_value: "{{ cmd_id_start_publish }}"
         get_attribute: command_id
         select: SPECIFIC_ATTRIBUTES
         comparisonoperator: EQ
         state: scan
-      register: cmd_remaining_compact_jobs
-      until: cmd_remaining_compact_jobs.item != []
-      retries: 120
+      register: cmd_remain_compact_jobs
+      until: cmd_remain_compact_jobs.item != []
+      retries:  720
       delay: 5
 
     - set_fact:
-        cmd_id: "{{ item.command_id.S }}"
+        cmd_id_remain_compact_jobs: "{{ item.command_id.S }}"
       with_items:
-        "{{ cmd_remaining_compact_jobs.item }}"
+        "{{ cmd_remain_compact_jobs.item }}"
 
     - name: Scan if remaining publish instances are stopped
       dynamodb_search:
         table_name: "{{ dynamodb_tablename }}"
         attribute: last_command
-        attribute_value: "{{ cmd_id }}"
+        attribute_value: "{{ cmd_id_remain_compact_jobs }}"
         get_attribute: command_id
         select: SPECIFIC_ATTRIBUTES
         comparisonoperator: EQ
         state: scan
-      register: cmd_stop_publish
-      until: cmd_stop_publish.item != []
-      retries: 120
+      register: cmd_stop_remain_publish
+      until: cmd_stop_remain_publish.item != []
+      retries:  720
       delay: 5
 
     - set_fact:
-        cmd_id: "{{ item.command_id.S }}"
+        cmd_id_stop_remain_publish: "{{ item.command_id.S }}"
       with_items:
-        "{{ cmd_stop_publish.item }}"
+        "{{ cmd_stop_remain_publish.item }}"
 
     - name: Scan if remaining publish instances are compacted
       dynamodb_search:
         table_name: "{{ dynamodb_tablename }}"
         attribute: last_command
-        attribute_value: "{{ cmd_id }}"
+        attribute_value: "{{ cmd_id_stop_remain_publish }}"
         get_attribute: command_id
         select: SPECIFIC_ATTRIBUTES
         comparisonoperator: EQ
         state: scan
       register: cmd_compact_publish
       until: cmd_compact_publish.item != []
-      retries: 120
+      retries:  720
       delay: 5
 
     - set_fact:
-        cmd_id: "{{ item.command_id.S }}"
+        cmd_id_compact_publish: "{{ item.command_id.S }}"
       with_items:
         "{{ cmd_compact_publish.item }}"
 
@@ -236,74 +236,296 @@
       dynamodb_search:
         table_name: "{{ dynamodb_tablename }}"
         attribute: last_command
-        attribute_value: "{{ cmd_id }}"
+        attribute_value: "{{ cmd_id_compact_publish }}"
         get_attribute: command_id
         select: SPECIFIC_ATTRIBUTES
         comparisonoperator: EQ
         state: scan
-      register: cmd_start_publish
-      until: cmd_start_publish.item != []
-      retries: 120
+      register: cmd_start_remain_publish
+      until: cmd_start_remain_publish.item != []
+      retries:  720
       delay: 5
 
     - set_fact:
-        cmd_id: "{{ item.command_id.S }}"
+        cmd_id_start_remain_publish: "{{ item.command_id.S }}"
       with_items:
-        "{{ cmd_start_publish.item }}"
+        "{{ cmd_start_remain_publish.item }}"
 
     - name: Query if offline-compaction-snapshot was successful
       dynamodb_search:
         table_name: "{{ dynamodb_tablename }}"
         attribute: command_id
-        attribute_value: "{{ cmd_id }}"
+        attribute_value: "{{ cmd_id_start_remain_publish }}"
         get_attribute: state
         select: SPECIFIC_ATTRIBUTES
         comparisonoperator: EQ
         state: query
       register: dbquery
       until: dbquery.item[0].state.S == "Success" or dbquery.item[0].state.S == "Failed"
-      # The retry values should mirror the TTL of the ssm.send_command of the Lambda function.
-      retries: 120
+      retries:  720
       delay: 5
 
     - name: Get path to output files
       aws_s3:
         mode: list
         bucket: "{{ s3.bucket }}"
-        prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id }}"
-      register: output_files
+        prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_stop_author_standby }}"
+      register: output_files_stop_author_standby
+
+    - name: Get path to output files
+      aws_s3:
+        mode: list
+        bucket: "{{ s3.bucket }}"
+        prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_stop_author_primary }}"
+      register: output_files_stop_author_primary
+
+    - name: Get path to output files
+      aws_s3:
+        mode: list
+        bucket: "{{ s3.bucket }}"
+        prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_stop_publish }}"
+      register: output_files_stop_publish
+
+    - name: Get path to output files
+      aws_s3:
+        mode: list
+        bucket: "{{ s3.bucket }}"
+        prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_offline_compaction }}"
+      register: output_files_offline_compaction
+
+    - name: Get path to output files
+      aws_s3:
+        mode: list
+        bucket: "{{ s3.bucket }}"
+        prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_offline_backup }}"
+      register: output_files_offline_backup
+
+    - name: Get path to output files
+      aws_s3:
+        mode: list
+        bucket: "{{ s3.bucket }}"
+        prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_start_author_primary }}"
+      register: output_files_start_author_primary
+
+    - name: Get path to output files
+      aws_s3:
+        mode: list
+        bucket: "{{ s3.bucket }}"
+        prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_start_author_standby }}"
+      register: output_files_start_author_standby
+
+    - name: Get path to output files
+      aws_s3:
+        mode: list
+        bucket: "{{ s3.bucket }}"
+        prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_start_publish }}"
+      register: output_files_start_publish
+
+    - name: Get path to output files
+      aws_s3:
+        mode: list
+        bucket: "{{ s3.bucket }}"
+        prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_remain_compact_jobs }}"
+      register: output_files_remain_compact_jobs
+
+    - name: Get path to output files
+      aws_s3:
+        mode: list
+        bucket: "{{ s3.bucket }}"
+        prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_stop_remain_publish }}"
+      register: output_files_stop_remain_publish
+
+    - name: Get path to output files
+      aws_s3:
+        mode: list
+        bucket: "{{ s3.bucket }}"
+        prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_compact_publish }}"
+      register: output_files_compact_publish
+
+    - name: Get path to output files
+      aws_s3:
+        mode: list
+        bucket: "{{ s3.bucket }}"
+        prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_start_remain_publish }}"
+      register: output_files_start_remain_publish
 
     - name: Set facts for getting command output
       set_fact:
         log_path: "{{ playbook_dir }}/logs/"
-        dl_path: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id }}"
-        s3_files: "{{ output_files.s3_keys }}"
+        dl_path_stop_author_standby: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_stop_author_standby }}"
+        dl_path_stop_author_primary: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_stop_author_primary }}"
+        dl_path_stop_publish: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_stop_publish }}"
+        dl_path_offline_compaction: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{cmd_id_offline_compaction}}"
+        dl_path_offline_backup: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_offline_backup }}"
+        dl_path_start_author_primary: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_start_author_primary }}"
+        dl_path_start_author_standby: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_start_author_standby }}"
+        dl_path_start_publish: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_start_publish }}"
+        dl_path_remain_compact_jobs: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{cmd_id_remain_compact_jobs}}"
+        dl_path_stop_remain_publish: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{cmd_id_stop_remain_publish}}"
+        dl_path_compact_publish: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{cmd_id_compact_publish}}"
+        dl_path_start_remain_publish: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{cmd_id_start_remain_publish}}"
+        s3_files_stop_author_standby: "{{ output_files_stop_author_standby.s3_keys }}"
+        s3_files_stop_author_primary: "{{ output_files_stop_author_primary.s3_keys }}"
+        s3_files_stop_publish: "{{ output_files_stop_publish.s3_keys }}"
+        s3_files_offline_compaction: "{{ output_files_offline_compaction.s3_keys }}"
+        s3_files_offline_backup: "{{ output_files_offline_backup.s3_keys }}"
+        s3_files_start_author_primary: "{{ output_files_start_author_primary.s3_keys }}"
+        s3_files_start_author_standby: "{{ output_files_start_author_standby.s3_keys }}"
+        s3_files_start_publish: "{{ output_files_start_publish.s3_keys }}"
+        s3_files_remain_compact_jobs: "{{ output_files_remain_compact_jobs.s3_keys }}"
+        s3_files_stop_remain_publish: "{{ output_files_stop_remain_publish.s3_keys }}"
+        s3_files_compact_publish: "{{ output_files_compact_publish.s3_keys }}"
+        s3_files_start_remain_publish: "{{ output_files_start_remain_publish.s3_keys }}"
 
-    - name: "Create Download directory in {{log_path }}{{ dl_path }}"
+    - name: "Create Download directory"
       file:
         path: "{{ log_path }}{{ item|regex_replace('(stdout|stderr)$', '') }}"
         state: directory
       with_items:
-        - "{{ s3_files }}"
+        - "{{ s3_files_stop_author_standby }}"
+        - "{{ s3_files_stop_author_primary }}"
+        - "{{ s3_files_stop_author_standby }}"
+        - "{{ s3_files_stop_publish }}"
+        - "{{ s3_files_offline_compaction }}"
+        - "{{ s3_files_offline_backup }}"
+        - "{{ s3_files_start_author_primary }}"
+        - "{{ s3_files_start_author_standby }}"
+        - "{{ s3_files_start_publish }}"
+        - "{{ s3_files_remain_compact_jobs }}"
+        - "{{ s3_files_stop_remain_publish }}"
+        - "{{ s3_files_compact_publish }}"
+        - "{{ s3_files_start_remain_publish }}"
 
-    - name: "Save command output to {{log_path }}{{ dl_path }}"
+    - name: "Save command output to {{log_path }}"
       aws_s3:
         mode: get
         bucket: "{{ s3.bucket }}"
         object: "{{ item }}"
         dest: "{{ log_path }}{{ item }}"
       with_items:
-        - "{{ s3_files }}"
-      register: saved_files
+        - "{{ s3_files_stop_author_standby }}"
+        - "{{ s3_files_stop_author_primary }}"
+        - "{{ s3_files_stop_author_standby }}"
+        - "{{ s3_files_stop_publish }}"
+        - "{{ s3_files_offline_compaction }}"
+        - "{{ s3_files_offline_backup }}"
+        - "{{ s3_files_start_author_primary }}"
+        - "{{ s3_files_start_author_standby }}"
+        - "{{ s3_files_start_publish }}"
+        - "{{ s3_files_remain_compact_jobs }}"
+        - "{{ s3_files_stop_remain_publish }}"
+        - "{{ s3_files_compact_publish }}"
+        - "{{ s3_files_start_remain_publish }}"
 
-    - name: "Find error log files in {{log_path }}{{ dl_path }}"
+    - name: "Find error log files in {{log_path }}{{dl_path_stop_author_standby}}"
       find:
-        paths: "{{log_path }}{{ dl_path }}"
+        paths: "{{log_path }}{{ dl_path_stop_author_standby }}"
         file_type: file
         patterns: stderr
         recurse: yes
-      register: stderr_files
+      register: stderr_stop_author_standby
+
+    - name: "Find error log files in {{log_path }}{{dl_path_stop_author_primary}}"
+      find:
+        paths: "{{log_path }}{{ dl_path_stop_author_primary }}"
+        file_type: file
+        patterns: stderr
+        recurse: yes
+      register: stderr_stop_author_primary
+
+    - name: "Find error log files in {{log_path }}{{dl_path_stop_publish}}"
+      find:
+        paths: "{{log_path }}{{ dl_path_stop_publish }}"
+        file_type: file
+        patterns: stderr
+        recurse: yes
+      register: stderr_stop_publish
+
+    - name: "Find error log files in {{log_path }}{{dl_path_offline_compaction}}"
+      find:
+        paths: "{{log_path }}{{ dl_path_offline_compaction }}"
+        file_type: file
+        patterns: stderr
+        recurse: yes
+      register: stderr_offline_compaction
+
+    - name: "Find error log files in {{log_path }}{{dl_path_offline_backup}}"
+      find:
+        paths: "{{log_path }}{{ dl_path_offline_backup }}"
+        file_type: file
+        patterns: stderr
+        recurse: yes
+      register: stderr_offline_backup
+
+    - name: "Find error log files in {{log_path }}{{dl_path_start_author_primary}}"
+      find:
+        paths: "{{log_path }}{{ dl_path_start_author_primary }}"
+        file_type: file
+        patterns: stderr
+        recurse: yes
+      register: stderr_start_author_primary
+
+    - name: "Find error log files in {{log_path }}{{dl_path_start_author_standby}}"
+      find:
+        paths: "{{log_path }}{{ dl_path_start_author_standby }}"
+        file_type: file
+        patterns: stderr
+        recurse: yes
+      register: stderr_start_author_standby
+
+    - name: "Find error log files in {{log_path }}{{dl_path_start_publish}}"
+      find:
+        paths: "{{log_path }}{{ dl_path_start_publish }}"
+        file_type: file
+        patterns: stderr
+        recurse: yes
+      register: stderr_path_start_publish
+
+    - name: "Find error log files in {{log_path }}{{dl_path_remain_compact_jobs}}"
+      find:
+        paths: "{{log_path }}{{ dl_path_remain_compact_jobs }}"
+        file_type: file
+        patterns: stderr
+        recurse: yes
+      register: stderr_path_remain_compact_jobs
+
+    - name: "Find error log files in {{log_path }}{{dl_path_stop_remain_publish}}"
+      find:
+        paths: "{{log_path }}{{ dl_path_stop_remain_publish }}"
+        file_type: file
+        patterns: stderr
+        recurse: yes
+      register: stderr_path_stop_remain_publish
+
+    - name: "Find error log files in {{log_path }}{{dl_path_compact_publish}}"
+      find:
+        paths: "{{log_path }}{{ dl_path_compact_publish }}"
+        file_type: file
+        patterns: stderr
+        recurse: yes
+      register: stderr_path_compact_publish
+
+    - name: "Find error log files in {{log_path }}{{dl_path_start_remain_publish}}"
+      find:
+        paths: "{{log_path }}{{ dl_path_start_remain_publish }}"
+        file_type: file
+        patterns: stderr
+        recurse: yes
+      register: stderr_path_start_remain_publish
 
     - log_output:
         type: file
-        log_files: "{{ stderr_files.files | map(attribute='path')|list }}"
+        log_files: "{{ item.files | map(attribute='path')|list }}"
+      with_items:
+        - "{{stderr_stop_author_standby}}"
+        - "{{stderr_stop_author_primary}}"
+        - "{{stderr_stop_publish}}"
+        - "{{stderr_offline_compaction}}"
+        - "{{stderr_offline_backup}}"
+        - "{{stderr_start_author_primary}}"
+        - "{{stderr_start_author_standby}}"
+        - "{{stderr_path_start_publish}}"
+        - "{{stderr_path_remain_compact_jobs}}"
+        - "{{stderr_path_stop_remain_publish}}"
+        - "{{stderr_path_compact_publish}}"
+        - "{{stderr_path_start_remain_publish}}"

--- a/offline-snapshot.sh
+++ b/offline-snapshot.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+set -o errexit
+
+run_id=${RUN_ID:-$(date +%Y-%m-%d:%H:%M:%S)}
+log_path=logs/$run_id-send-message.log
+
+# Construct Ansible extra_vars flags.
+# If CONFIG_FILE is set, values will be added.
+
+extra_vars=(--extra-vars "stack_prefix=$stack_prefix")
+
+# shellcheck disable=SC2154
+extra_vars+=(--extra-vars "@$topic_config_file")
+
+# shellcheck disable=SC2154
+extra_vars+=(--extra-vars "@$message_config_file")
+
+if [ ! -z "$4" ]; then
+    extra_vars+=(--extra-vars "$4")
+fi
+
+mkdir -p logs
+echo "Sending Message SNS Topic"
+ANSIBLE_LOG_PATH=$log_path \
+  ansible-playbook offline-snapshot.yaml \
+  -v \
+  -i ansible/inventory/hosts \
+  --module-path ansible/library/ \
+  "${extra_vars[@]}"
+echo "Finished Sending Message to SNS Topic"

--- a/offline-snapshot.yaml
+++ b/offline-snapshot.yaml
@@ -34,11 +34,11 @@
         state: scan
       register: cmd_stop_author_standby
       until: cmd_stop_author_standby.item != []
-      retries: 120
+      retries:  720
       delay: 5
 
     - set_fact:
-        cmd_id: "{{ item.command_id.S }}"
+        cmd_id_stop_author_standby: "{{ item.command_id.S }}"
       with_items:
         "{{ cmd_stop_author_standby.item }}"
 
@@ -46,18 +46,18 @@
       dynamodb_search:
         table_name: "{{ dynamodb_tablename }}"
         attribute: last_command
-        attribute_value: "{{ cmd_id }}"
+        attribute_value: "{{ cmd_id_stop_author_standby }}"
         get_attribute: command_id
         select: SPECIFIC_ATTRIBUTES
         comparisonoperator: EQ
         state: scan
       register: cmd_stop_author_primary
       until: cmd_stop_author_primary.item != []
-      retries: 120
+      retries:  720
       delay: 5
 
     - set_fact:
-        cmd_id: "{{ item.command_id.S }}"
+        cmd_id_stop_author_primary: "{{ item.command_id.S }}"
       with_items:
         "{{ cmd_stop_author_primary.item }}"
 
@@ -65,18 +65,18 @@
       dynamodb_search:
         table_name: "{{ dynamodb_tablename }}"
         attribute: last_command
-        attribute_value: "{{ cmd_id }}"
+        attribute_value: "{{ cmd_id_stop_author_primary }}"
         get_attribute: command_id
         select: SPECIFIC_ATTRIBUTES
         comparisonoperator: EQ
         state: scan
       register: cmd_stop_publish
       until: cmd_stop_publish.item != []
-      retries: 120
+      retries:  720
       delay: 5
 
     - set_fact:
-        cmd_id: "{{ item.command_id.S }}"
+        cmd_id_stop_publish: "{{ item.command_id.S }}"
       with_items:
         "{{ cmd_stop_publish.item }}"
 
@@ -84,18 +84,18 @@
       dynamodb_search:
         table_name: "{{ dynamodb_tablename }}"
         attribute: last_command
-        attribute_value: "{{ cmd_id }}"
+        attribute_value: "{{ cmd_id_stop_publish }}"
         get_attribute: command_id
         select: SPECIFIC_ATTRIBUTES
         comparisonoperator: EQ
         state: scan
       register: cmd_offline_backup
       until: cmd_offline_backup.item != []
-      retries: 120
+      retries:  720
       delay: 5
 
     - set_fact:
-        cmd_id: "{{ item.command_id.S }}"
+        cmd_id_offline_backup: "{{ item.command_id.S }}"
       with_items:
         "{{ cmd_offline_backup.item }}"
 
@@ -103,18 +103,18 @@
       dynamodb_search:
         table_name: "{{ dynamodb_tablename }}"
         attribute: last_command
-        attribute_value: "{{ cmd_id }}"
+        attribute_value: "{{ cmd_id_offline_backup }}"
         get_attribute: command_id
         select: SPECIFIC_ATTRIBUTES
         comparisonoperator: EQ
         state: scan
       register: cmd_start_author_primary
       until: cmd_start_author_primary.item != []
-      retries: 120
+      retries:  720
       delay: 5
 
     - set_fact:
-        cmd_id: "{{ item.command_id.S }}"
+        cmd_id_start_author_primary: "{{ item.command_id.S }}"
       with_items:
         "{{ cmd_start_author_primary.item }}"
 
@@ -122,18 +122,18 @@
       dynamodb_search:
         table_name: "{{ dynamodb_tablename }}"
         attribute: last_command
-        attribute_value: "{{ cmd_id }}"
+        attribute_value: "{{ cmd_id_start_author_primary }}"
         get_attribute: command_id
         select: SPECIFIC_ATTRIBUTES
         comparisonoperator: EQ
         state: scan
       register: cmd_start_author_standby
       until: cmd_start_author_standby.item != []
-      retries: 120
+      retries:  720
       delay: 5
 
     - set_fact:
-        cmd_id: "{{ item.command_id.S }}"
+        cmd_id_start_author_standby: "{{ item.command_id.S }}"
       with_items:
         "{{ cmd_start_author_standby.item }}"
 
@@ -141,18 +141,18 @@
       dynamodb_search:
         table_name: "{{ dynamodb_tablename }}"
         attribute: last_command
-        attribute_value: "{{ cmd_id }}"
+        attribute_value: "{{ cmd_id_start_author_standby }}"
         get_attribute: command_id
         select: SPECIFIC_ATTRIBUTES
         comparisonoperator: EQ
         state: scan
       register: cmd_start_publish
       until: cmd_start_publish.item != []
-      retries: 120
+      retries:  720
       delay: 5
 
     - set_fact:
-        cmd_id: "{{ item.command_id.S }}"
+        cmd_id_start_publish: "{{ item.command_id.S }}"
       with_items:
         "{{ cmd_start_publish.item }}"
 
@@ -160,7 +160,7 @@
       dynamodb_search:
         table_name: "{{ dynamodb_tablename }}"
         attribute: command_id
-        attribute_value: "{{ cmd_id }}"
+        attribute_value: "{{ cmd_id_start_publish }}"
         get_attribute: state
         select: SPECIFIC_ATTRIBUTES
         comparisonoperator: EQ
@@ -168,47 +168,170 @@
       register: dbquery
       until: dbquery.item[0].state.S == "Success" or dbquery.item[0].state.S == "Failed"
       # The retry values should mirror the TTL of the ssm.send_command of the Lambda function.
-      retries: 120
+      retries:  720
       delay: 5
 
     - name: Get path to output files
       aws_s3:
         mode: list
         bucket: "{{ s3.bucket }}"
-        prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id }}"
-      register: output_files
+        prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_stop_author_standby }}"
+      register: output_files_stop_author_standby
+
+    - name: Get path to output files
+      aws_s3:
+        mode: list
+        bucket: "{{ s3.bucket }}"
+        prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_stop_author_primary }}"
+      register: output_files_stop_author_primary
+
+    - name: Get path to output files
+      aws_s3:
+        mode: list
+        bucket: "{{ s3.bucket }}"
+        prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_stop_publish }}"
+      register: output_files_stop_publish
+
+    - name: Get path to output files
+      aws_s3:
+        mode: list
+        bucket: "{{ s3.bucket }}"
+        prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_offline_backup }}"
+      register: output_files_offline_backup
+
+    - name: Get path to output files
+      aws_s3:
+        mode: list
+        bucket: "{{ s3.bucket }}"
+        prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_start_author_primary }}"
+      register: output_files_start_author_primary
+
+    - name: Get path to output files
+      aws_s3:
+        mode: list
+        bucket: "{{ s3.bucket }}"
+        prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_start_author_standby }}"
+      register: output_files_start_author_standby
+
+    - name: Get path to output files
+      aws_s3:
+        mode: list
+        bucket: "{{ s3.bucket }}"
+        prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_start_publish }}"
+      register: output_files_start_publish
 
     - name: Set facts for getting command output
       set_fact:
         log_path: "{{ playbook_dir }}/logs/"
-        dl_path: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id }}"
-        s3_files: "{{ output_files.s3_keys }}"
+        dl_path_stop_author_standby: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_stop_author_standby }}"
+        dl_path_stop_author_primary: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_stop_author_primary }}"
+        dl_path_stop_publish: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_stop_publish }}"
+        dl_path_offline_backup: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_offline_backup }}"
+        dl_path_start_author_primary: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_start_author_primary }}"
+        dl_path_start_author_standby: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_start_author_standby }}"
+        dl_path_start_publish: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_start_publish }}"
+        s3_files_stop_author_standby: "{{ output_files_stop_author_standby.s3_keys }}"
+        s3_files_stop_author_primary: "{{ output_files_stop_author_primary.s3_keys }}"
+        s3_files_stop_publish: "{{ output_files_stop_publish.s3_keys }}"
+        s3_files_offline_backup: "{{ output_files_offline_backup.s3_keys }}"
+        s3_files_start_author_primary: "{{ output_files_start_author_primary.s3_keys }}"
+        s3_files_start_author_standby: "{{ output_files_start_author_standby.s3_keys }}"
+        s3_files_start_publish: "{{ output_files_start_publish.s3_keys }}"
 
-    - name: "Create Download directory in {{log_path }}{{ dl_path }}"
+    - name: "Create Download directory"
       file:
         path: "{{ log_path }}{{ item|regex_replace('(stdout|stderr)$', '') }}"
         state: directory
       with_items:
-        - "{{ s3_files }}"
+        - "{{ s3_files_stop_author_standby }}"
+        - "{{ s3_files_stop_author_primary }}"
+        - "{{ s3_files_stop_author_standby }}"
+        - "{{ s3_files_stop_publish }}"
+        - "{{ s3_files_offline_backup }}"
+        - "{{ s3_files_start_author_primary }}"
+        - "{{ s3_files_start_author_standby }}"
+        - "{{ s3_files_start_publish }}"
 
-    - name: "Save command output to {{log_path }}{{ dl_path }}"
+    - name: "Save command output to {{log_path }}"
       aws_s3:
         mode: get
         bucket: "{{ s3.bucket }}"
         object: "{{ item }}"
         dest: "{{ log_path }}{{ item }}"
       with_items:
-        - "{{ s3_files }}"
-      register: saved_files
+        - "{{ s3_files_stop_author_standby }}"
+        - "{{ s3_files_stop_author_primary }}"
+        - "{{ s3_files_stop_author_standby }}"
+        - "{{ s3_files_stop_publish }}"
+        - "{{ s3_files_offline_backup }}"
+        - "{{ s3_files_start_author_primary }}"
+        - "{{ s3_files_start_author_standby }}"
+        - "{{ s3_files_start_publish }}"
 
-    - name: "Find error log files in {{log_path }}{{ dl_path }}"
+    - name: "Find error log files in {{log_path }}{{dl_path_stop_author_standby}}"
       find:
-        paths: "{{log_path }}{{ dl_path }}"
+        paths: "{{log_path }}{{ dl_path_stop_author_standby }}"
         file_type: file
         patterns: stderr
         recurse: yes
-      register: stderr_files
+      register: stderr_stop_author_standby
+
+    - name: "Find error log files in {{log_path }}{{dl_path_stop_author_primary}}"
+      find:
+        paths: "{{log_path }}{{ dl_path_stop_author_primary }}"
+        file_type: file
+        patterns: stderr
+        recurse: yes
+      register: stderr_stop_author_primary
+
+    - name: "Find error log files in {{log_path }}{{dl_path_stop_publish}}"
+      find:
+        paths: "{{log_path }}{{ dl_path_stop_publish }}"
+        file_type: file
+        patterns: stderr
+        recurse: yes
+      register: stderr_stop_publish
+
+    - name: "Find error log files in {{log_path }}{{dl_path_offline_backup}}"
+      find:
+        paths: "{{log_path }}{{ dl_path_offline_backup }}"
+        file_type: file
+        patterns: stderr
+        recurse: yes
+      register: stderr_offline_backup
+
+    - name: "Find error log files in {{log_path }}{{dl_path_start_author_primary}}"
+      find:
+        paths: "{{log_path }}{{ dl_path_start_author_primary }}"
+        file_type: file
+        patterns: stderr
+        recurse: yes
+      register: stderr_start_author_primary
+
+    - name: "Find error log files in {{log_path }}{{dl_path_start_author_standby}}"
+      find:
+        paths: "{{log_path }}{{ dl_path_start_author_standby }}"
+        file_type: file
+        patterns: stderr
+        recurse: yes
+      register: stderr_start_author_standby
+
+    - name: "Find error log files in {{log_path }}{{dl_path_start_author_standby}}"
+      find:
+        paths: "{{log_path }}{{ dl_path_start_publish }}"
+        file_type: file
+        patterns: stderr
+        recurse: yes
+      register: stderr_path_start_publish
 
     - log_output:
         type: file
-        log_files: "{{ stderr_files.files | map(attribute='path')|list }}"
+        log_files: "{{ item.files | map(attribute='path')|list }}"
+      with_items:
+        - "{{stderr_stop_author_standby}}"
+        - "{{stderr_stop_author_primary}}"
+        - "{{stderr_stop_publish}}"
+        - "{{stderr_offline_backup}}"
+        - "{{stderr_start_author_primary}}"
+        - "{{stderr_start_author_standby}}"
+        - "{{stderr_path_start_publish}}"

--- a/offline-snapshot.yaml
+++ b/offline-snapshot.yaml
@@ -1,0 +1,214 @@
+---
+- name: SNS Message Sender
+  hosts: all
+  gather_facts: no
+  connection: local
+
+  vars:
+    message_file:
+# files are in .txt as they need to replace the variables e.g. 'stack_prefix' (un-quoted) which breaks the json validation.
+# if the variables were in double quotes, they would not be replaced with the value.
+    message: "{{ lookup('file', message_file) }}"
+
+  tasks:
+
+    - debug:
+        msg: "Send message: {{ message }} with subject: {{ subject }} to topic: {{ sns_topic }} in region: {{ aws_region }}"
+
+    - name: Send message to SNS Topic
+      sns:
+        msg: "{{ message }}"
+        subject: "{{ subject }}"
+        topic: "{{ sns_topic }}"
+        region: "{{ aws_region }}"
+      register: publish_message
+
+    - name: Scan if author standby instance is stopped
+      dynamodb_search:
+        table_name: "{{ dynamodb_tablename }}"
+        attribute: message_id
+        attribute_value: "{{ publish_message.item.PublishResponse.PublishResult.MessageId }}"
+        get_attribute: command_id
+        select: SPECIFIC_ATTRIBUTES
+        comparisonoperator: EQ
+        state: scan
+      register: cmd_stop_author_standby
+      until: cmd_stop_author_standby.item != []
+      retries: 120
+      delay: 5
+
+    - set_fact:
+        cmd_id: "{{ item.command_id.S }}"
+      with_items:
+        "{{ cmd_stop_author_standby.item }}"
+
+    - name: Scan if author primary instance is stopped
+      dynamodb_search:
+        table_name: "{{ dynamodb_tablename }}"
+        attribute: last_command
+        attribute_value: "{{ cmd_id }}"
+        get_attribute: command_id
+        select: SPECIFIC_ATTRIBUTES
+        comparisonoperator: EQ
+        state: scan
+      register: cmd_stop_author_primary
+      until: cmd_stop_author_primary.item != []
+      retries: 120
+      delay: 5
+
+    - set_fact:
+        cmd_id: "{{ item.command_id.S }}"
+      with_items:
+        "{{ cmd_stop_author_primary.item }}"
+
+    - name: Scan if publish instance is stopped
+      dynamodb_search:
+        table_name: "{{ dynamodb_tablename }}"
+        attribute: last_command
+        attribute_value: "{{ cmd_id }}"
+        get_attribute: command_id
+        select: SPECIFIC_ATTRIBUTES
+        comparisonoperator: EQ
+        state: scan
+      register: cmd_stop_publish
+      until: cmd_stop_publish.item != []
+      retries: 120
+      delay: 5
+
+    - set_fact:
+        cmd_id: "{{ item.command_id.S }}"
+      with_items:
+        "{{ cmd_stop_publish.item }}"
+
+    - name: Scan if offline-backup is executed
+      dynamodb_search:
+        table_name: "{{ dynamodb_tablename }}"
+        attribute: last_command
+        attribute_value: "{{ cmd_id }}"
+        get_attribute: command_id
+        select: SPECIFIC_ATTRIBUTES
+        comparisonoperator: EQ
+        state: scan
+      register: cmd_offline_backup
+      until: cmd_offline_backup.item != []
+      retries: 120
+      delay: 5
+
+    - set_fact:
+        cmd_id: "{{ item.command_id.S }}"
+      with_items:
+        "{{ cmd_offline_backup.item }}"
+
+    - name: Scan if author primary instance is started
+      dynamodb_search:
+        table_name: "{{ dynamodb_tablename }}"
+        attribute: last_command
+        attribute_value: "{{ cmd_id }}"
+        get_attribute: command_id
+        select: SPECIFIC_ATTRIBUTES
+        comparisonoperator: EQ
+        state: scan
+      register: cmd_start_author_primary
+      until: cmd_start_author_primary.item != []
+      retries: 120
+      delay: 5
+
+    - set_fact:
+        cmd_id: "{{ item.command_id.S }}"
+      with_items:
+        "{{ cmd_start_author_primary.item }}"
+
+    - name: Scan if author standby instance is started
+      dynamodb_search:
+        table_name: "{{ dynamodb_tablename }}"
+        attribute: last_command
+        attribute_value: "{{ cmd_id }}"
+        get_attribute: command_id
+        select: SPECIFIC_ATTRIBUTES
+        comparisonoperator: EQ
+        state: scan
+      register: cmd_start_author_standby
+      until: cmd_start_author_standby.item != []
+      retries: 120
+      delay: 5
+
+    - set_fact:
+        cmd_id: "{{ item.command_id.S }}"
+      with_items:
+        "{{ cmd_start_author_standby.item }}"
+
+    - name: Scan if publish instance is started
+      dynamodb_search:
+        table_name: "{{ dynamodb_tablename }}"
+        attribute: last_command
+        attribute_value: "{{ cmd_id }}"
+        get_attribute: command_id
+        select: SPECIFIC_ATTRIBUTES
+        comparisonoperator: EQ
+        state: scan
+      register: cmd_start_publish
+      until: cmd_start_publish.item != []
+      retries: 120
+      delay: 5
+
+    - set_fact:
+        cmd_id: "{{ item.command_id.S }}"
+      with_items:
+        "{{ cmd_start_publish.item }}"
+
+    - name: Query if offline-snapshot was successful
+      dynamodb_search:
+        table_name: "{{ dynamodb_tablename }}"
+        attribute: command_id
+        attribute_value: "{{ cmd_id }}"
+        get_attribute: state
+        select: SPECIFIC_ATTRIBUTES
+        comparisonoperator: EQ
+        state: query
+      register: dbquery
+      until: dbquery.item[0].state.S == "Success" or dbquery.item[0].state.S == "Failed"
+      # The retry values should mirror the TTL of the ssm.send_command of the Lambda function.
+      retries: 120
+      delay: 5
+
+    - name: Get path to output files
+      aws_s3:
+        mode: list
+        bucket: "{{ s3.bucket }}"
+        prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id }}"
+      register: output_files
+
+    - name: Set facts for getting command output
+      set_fact:
+        log_path: "{{ playbook_dir }}/logs/"
+        dl_path: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id }}"
+        s3_files: "{{ output_files.s3_keys }}"
+
+    - name: "Create Download directory in {{log_path }}{{ dl_path }}"
+      file:
+        path: "{{ log_path }}{{ item|regex_replace('(stdout|stderr)$', '') }}"
+        state: directory
+      with_items:
+        - "{{ s3_files }}"
+
+    - name: "Save command output to {{log_path }}{{ dl_path }}"
+      aws_s3:
+        mode: get
+        bucket: "{{ s3.bucket }}"
+        object: "{{ item }}"
+        dest: "{{ log_path }}{{ item }}"
+      with_items:
+        - "{{ s3_files }}"
+      register: saved_files
+
+    - name: "Find error log files in {{log_path }}{{ dl_path }}"
+      find:
+        paths: "{{log_path }}{{ dl_path }}"
+        file_type: file
+        patterns: stderr
+        recurse: yes
+      register: stderr_files
+
+    - log_output:
+        type: file
+        log_files: "{{ stderr_files.files | map(attribute='path')|list }}"


### PR DESCRIPTION
Due to the differences of the command execution during taking offline-snapshot and offline-compaction-snapshot those two processes need a own ansible playbook in order to query the command state. 

Regarding issue https://github.com/shinesolutions/aem-stack-manager-messenger/issues/16