### PR TITLE
Enhancement/error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
  * add command export-packages
  * add polling state of the sent command
  * add ansible module to output the log of the sent command to stdout
- * add ansible playbook for offline-snapshot and offline-compaction-snapshot
+ * add ansible playbook for offline-snapshot and offline-compaction-snapsho
+ * Improvement of the error handling
 
 
 ### 1.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
  * add command export-packages
  * add polling state of the sent command
  * add ansible module to output the log of the sent command to stdout
- * add ansible playbook for offline-snapshot and offline-compaction-snapsho
+ * add ansible playbook for offline-snapshot and offline-compaction-snapshot
  * Improvement of the error handling
 
 

--- a/offline-compaction-snapshot.yaml
+++ b/offline-compaction-snapshot.yaml
@@ -53,7 +53,7 @@
         state: query
       register: dbquery_state_stop_author_standby
 
-    - name: Check for error
+    - name: Check for error when stopping Author Standby Service
       set_fact:
         error_stop_author_standby: 1
         module_error: 1
@@ -89,7 +89,7 @@
         state: query
       register: dbquery_state_stop_author_primary
 
-    - name: Check for error
+    - name: Check for error when stopping Author Primary Service
       set_fact:
         error_stop_author_primary: 1
         module_error: 1
@@ -125,7 +125,7 @@
         state: query
       register: dbquery_state_stop_publish
 
-    - name: Check for error
+    - name: Check for error when stopping Publish Service
       set_fact:
         error_stop_publish: 1
         module_error: 1
@@ -161,7 +161,7 @@
         state: query
       register: dbquery_state_offline_compaction
 
-    - name: Check for error
+    - name: Check for error when taking offline compaction
       set_fact:
         error_offline_compaction: 1
         module_error: 1
@@ -197,7 +197,7 @@
         state: query
       register: dbquery_state_offline_snapshot
 
-    - name: Check for error
+    - name: Check for error when taking offline backup
       set_fact:
         error_offline_snapshot: 1
         module_error: 1
@@ -233,7 +233,7 @@
         state: query
       register: dbquery_state_start_author_primary
 
-    - name: Check for error
+    - name: Check for error when starting Author Primary Service
       set_fact:
         error_start_author_primary: 1
         module_error: 1
@@ -269,7 +269,7 @@
         state: query
       register: dbquery_state_start_author_standby
 
-    - name: Check for error
+    - name: Check for error when starting Author Standby Service
       set_fact:
         error_start_author_standby: 1
         module_error: 1
@@ -305,7 +305,7 @@
         state: query
       register: dbquery_state_start_publish
 
-    - name: Check for error
+    - name: Check for error when starting Publish Service
       set_fact:
         error_start_publish: 1
         module_error: 1
@@ -341,7 +341,7 @@
         state: query
       register: dbquery_remain_compact_jobs
 
-    - name: Check for error
+    - name: Check for error when checking for remaining compact jobs
       set_fact:
         error_remain_compact_jobs: 1
         module_error: 1
@@ -377,7 +377,7 @@
         state: query
       register: dbquery_stop_remain_publish
 
-    - name: Check for error
+    - name: Check for error when stoppping remaining Publish Service
       set_fact:
         error_stop_remain_publish: 1
         module_error: 1
@@ -413,7 +413,7 @@
         state: query
       register: dbquery_compact_publish
 
-    - name: Check for error
+    - name: Check for error when compact remaining Publisher
       set_fact:
         error_remain_compact_publish: 1
         module_error: 1
@@ -449,7 +449,7 @@
         state: query
       register: dbquery_start_remain_publish
 
-    - name: Check for error
+    - name: Check for error when starting remaining Publisher
       set_fact:
         error_start_remain_publish: 1
         module_error: 1
@@ -474,7 +474,7 @@
         general_error: 1
       when: dbquery.item[0].state.S == "Failed"
 
-    - name: Get path to output files
+    - name: Get path to output files of stopping Author Standby Service
       aws_s3:
         mode: list
         bucket: "{{ s3.bucket }}"
@@ -482,7 +482,7 @@
       register: output_files_stop_author_standby
       When: cmd_id_stop_author_standby is defined
 
-    - name: Get path to output files
+    - name: Get path to output files of stopping Author Primary Service
       aws_s3:
         mode: list
         bucket: "{{ s3.bucket }}"
@@ -490,7 +490,7 @@
       register: output_files_stop_author_primary
       When: cmd_id_stop_author_primary is defined
 
-    - name: Get path to output files
+    - name: Get path to output files of stopping Publish Service
       aws_s3:
         mode: list
         bucket: "{{ s3.bucket }}"
@@ -498,7 +498,7 @@
       register: output_files_stop_publish
       When: cmd_id_stop_publish is defined
 
-    - name: Get path to output files
+    - name: Get path to output files of taking offline compaction
       aws_s3:
         mode: list
         bucket: "{{ s3.bucket }}"
@@ -506,7 +506,7 @@
       register: output_files_offline_compaction
       When: cmd_id_offline_compaction is defined
 
-    - name: Get path to output files
+    - name: Get path to output files of taking offline backup
       aws_s3:
         mode: list
         bucket: "{{ s3.bucket }}"
@@ -514,7 +514,7 @@
       register: output_files_offline_backup
       When: cmd_id_offline_backup is defined
 
-    - name: Get path to output files
+    - name: Get path to output files of starting Author Primary Service
       aws_s3:
         mode: list
         bucket: "{{ s3.bucket }}"
@@ -522,7 +522,7 @@
       register: output_files_start_author_primary
       When: cmd_id_start_author_primary is defined
 
-    - name: Get path to output files
+    - name: Get path to output files of starting Author Standby Service
       aws_s3:
         mode: list
         bucket: "{{ s3.bucket }}"
@@ -530,7 +530,7 @@
       register: output_files_start_author_standby
       When: cmd_id_start_author_standby is defined
 
-    - name: Get path to output files
+    - name: Get path to output files of starting Publish Service
       aws_s3:
         mode: list
         bucket: "{{ s3.bucket }}"
@@ -538,7 +538,7 @@
       register: output_files_start_publish
       When: cmd_id_start_publish is defined
 
-    - name: Get path to output files
+    - name: Get path to output files of checking remaining compaction jobs
       aws_s3:
         mode: list
         bucket: "{{ s3.bucket }}"
@@ -546,7 +546,7 @@
       register: output_files_remain_compact_jobs
       When: cmd_id_remain_compact_jobs is defined
 
-    - name: Get path to output files
+    - name: Get path to output files of stopping remaining publisher
       aws_s3:
         mode: list
         bucket: "{{ s3.bucket }}"
@@ -554,7 +554,7 @@
       register: output_files_stop_remain_publish
       When: cmd_id_stop_remain_publish is defined
 
-    - name: Get path to output files
+    - name: Get path to output files of compact remaining publisher
       aws_s3:
         mode: list
         bucket: "{{ s3.bucket }}"
@@ -562,7 +562,7 @@
       register: output_files_compact_publish
       When: cmd_id_compact_publish is defined
 
-    - name: Get path to output files
+    - name: Get path to output files of starting remaining publisher
       aws_s3:
         mode: list
         bucket: "{{ s3.bucket }}"
@@ -646,7 +646,7 @@
         s3_files_start_remain_publish: "{{ output_files_start_remain_publish.s3_keys }}"
       when: error_start_remain_publish is defined or general_error is defined
 
-    - name: "Create Download directory"
+    - name: "Create Download directory of stopping Author Standby Service"
       file:
         path: "{{ log_path }}{{ item|regex_replace('(stdout|stderr)$', '') }}"
         state: directory
@@ -654,7 +654,7 @@
         - "{{ s3_files_stop_author_standby }}"
       when: error_stop_author_standby is defined or general_error is defined
 
-    - name: "Create Download directory"
+    - name: "Create Download directory of stopping Author Primary Service"
       file:
         path: "{{ log_path }}{{ item|regex_replace('(stdout|stderr)$', '') }}"
         state: directory
@@ -662,7 +662,7 @@
         - "{{ s3_files_stop_author_primary }}"
       when: error_stop_author_primary is defined or general_error is defined
 
-    - name: "Create Download directory"
+    - name: "Create Download directory of stopping Publish Service"
       file:
         path: "{{ log_path }}{{ item|regex_replace('(stdout|stderr)$', '') }}"
         state: directory
@@ -670,7 +670,7 @@
         - "{{ s3_files_stop_publish }}"
       when: error_stop_publish is defined or general_error is defined
 
-    - name: "Create Download directory"
+    - name: "Create Download directory of taking offline compaction"
       file:
         path: "{{ log_path }}{{ item|regex_replace('(stdout|stderr)$', '') }}"
         state: directory
@@ -678,7 +678,7 @@
       - "{{ s3_files_offline_compaction }}"
       when: error_offline_compaction is defined or general_error is defined
 
-    - name: "Create Download directory"
+    - name: "Create Download directory of taking offline backup Service"
       file:
         path: "{{ log_path }}{{ item|regex_replace('(stdout|stderr)$', '') }}"
         state: directory
@@ -686,7 +686,7 @@
       - "{{ s3_files_offline_backup }}"
       when: error_offline_snapshot is defined or general_error is defined
 
-    - name: "Create Download directory"
+    - name: "Create Download directory of starting Author Primary Service"
       file:
         path: "{{ log_path }}{{ item|regex_replace('(stdout|stderr)$', '') }}"
         state: directory
@@ -694,7 +694,7 @@
       - "{{ s3_files_start_author_primary }}"
       when: error_start_author_primary is defined or general_error is defined
 
-    - name: "Create Download directory"
+    - name: "Create Download directory of starting Author Standby Service"
       file:
         path: "{{ log_path }}{{ item|regex_replace('(stdout|stderr)$', '') }}"
         state: directory
@@ -702,7 +702,7 @@
       - "{{ s3_files_start_author_standby }}"
       when: error_start_author_standby is defined or general_error is defined
 
-    - name: "Create Download directory"
+    - name: "Create Download directory of starting Publish Service"
       file:
         path: "{{ log_path }}{{ item|regex_replace('(stdout|stderr)$', '') }}"
         state: directory
@@ -710,7 +710,7 @@
       - "{{ s3_files_start_publish }}"
       when: error_start_publish is defined or general_error is defined
 
-    - name: "Create Download directory"
+    - name: "Create Download directory of remaining compaction job"
       file:
         path: "{{ log_path }}{{ item|regex_replace('(stdout|stderr)$', '') }}"
         state: directory
@@ -718,7 +718,7 @@
       - "{{ s3_files_remain_compact_jobs }}"
       when: error_remain_compact_jobs is defined or general_error is defined
 
-    - name: "Create Download directory"
+    - name: "Create Download directory of stopping remaining Publisher"
       file:
         path: "{{ log_path }}{{ item|regex_replace('(stdout|stderr)$', '') }}"
         state: directory
@@ -726,7 +726,7 @@
       - "{{ s3_files_stop_remain_publish }}"
       when: error_stop_remain_publish is defined or general_error is defined
 
-    - name: "Create Download directory"
+    - name: "Create Download directory of compact remaining Publisher"
       file:
         path: "{{ log_path }}{{ item|regex_replace('(stdout|stderr)$', '') }}"
         state: directory
@@ -734,7 +734,7 @@
       - "{{ s3_files_compact_publish }}"
       when: error_remain_compact_publish is defined or general_error is defined
 
-    - name: "Create Download directory"
+    - name: "Create Download directory of starting remaining Publisher"
       file:
         path: "{{ log_path }}{{ item|regex_replace('(stdout|stderr)$', '') }}"
         state: directory
@@ -742,7 +742,7 @@
       - "{{ s3_files_start_remain_publish }}"
       when: error_start_remain_publish is defined or general_error is defined
 
-    - name: "Save command output to {{log_path }}"
+    - name: "Save command output stopping Author Standby Service to {{log_path }}"
       aws_s3:
         mode: get
         bucket: "{{ s3.bucket }}"
@@ -752,7 +752,7 @@
         - "{{ s3_files_stop_author_standby }}"
       when: error_stop_author_standby is defined or general_error is defined
 
-    - name: "Save command output to {{log_path }}"
+    - name: "Save command output stopping Author Primary Service to {{log_path }}"
       aws_s3:
         mode: get
         bucket: "{{ s3.bucket }}"
@@ -762,7 +762,7 @@
         - "{{ s3_files_stop_author_primary }}"
       when: error_stop_author_primary is defined or general_error is defined
 
-    - name: "Save command output to {{log_path }}"
+    - name: "Save command output stopping Publish Service to {{log_path }}"
       aws_s3:
         mode: get
         bucket: "{{ s3.bucket }}"
@@ -772,7 +772,7 @@
         - "{{ s3_files_stop_publish }}"
       when: error_stop_publish is defined or general_error is defined
 
-    - name: "Save command output to {{log_path }}"
+    - name: "Save command output taking opffline compaction to {{log_path }}"
       aws_s3:
         mode: get
         bucket: "{{ s3.bucket }}"
@@ -782,7 +782,7 @@
         - "{{ s3_files_offline_compaction }}"
       when: error_offline_compaction is defined or general_error is defined
 
-    - name: "Save command output to {{log_path }}"
+    - name: "Save command output taking offline backup to {{log_path }}"
       aws_s3:
         mode: get
         bucket: "{{ s3.bucket }}"
@@ -792,7 +792,7 @@
         - "{{ s3_files_offline_backup }}"
       when: error_offline_snapshot is defined or general_error is defined
 
-    - name: "Save command output to {{log_path }}"
+    - name: "Save command output starting Author Primary Service to {{log_path }}"
       aws_s3:
         mode: get
         bucket: "{{ s3.bucket }}"
@@ -802,7 +802,7 @@
         - "{{ s3_files_start_author_primary }}"
       when: error_start_author_primary is defined or general_error is defined
 
-    - name: "Save command output to {{log_path }}"
+    - name: "Save command output starting Author Standby Service to {{log_path }}"
       aws_s3:
         mode: get
         bucket: "{{ s3.bucket }}"
@@ -812,7 +812,7 @@
         - "{{ s3_files_start_author_standby }}"
       when: error_start_author_standby is defined or general_error is defined
 
-    - name: "Save command output to {{log_path }}"
+    - name: "Save command output starting Publish Service to {{log_path }}"
       aws_s3:
         mode: get
         bucket: "{{ s3.bucket }}"
@@ -822,7 +822,7 @@
         - "{{ s3_files_start_publish }}"
       when: error_start_publish is defined or general_error is defined
 
-    - name: "Save command output to {{log_path }}"
+    - name: "Save command output check for remaining compaction jobs to {{log_path }}"
       aws_s3:
         mode: get
         bucket: "{{ s3.bucket }}"
@@ -832,7 +832,7 @@
         - "{{ s3_files_remain_compact_jobs }}"
       when: error_remain_compact_jobs is defined or general_error is defined
 
-    - name: "Save command output to {{log_path }}"
+    - name: "Save command output stopping remaining Publisher to {{log_path }}"
       aws_s3:
         mode: get
         bucket: "{{ s3.bucket }}"
@@ -842,7 +842,7 @@
         - "{{ s3_files_stop_remain_publish }}"
       when: error_stop_remain_publish is defined or general_error is defined
 
-    - name: "Save command output to {{log_path }}"
+    - name: "Save command output taking remaining compaction to {{log_path }}"
       aws_s3:
         mode: get
         bucket: "{{ s3.bucket }}"
@@ -852,7 +852,7 @@
         - "{{ s3_files_compact_publish }}"
       when: error_remain_compact_publish is defined or general_error is defined
 
-    - name: "Save command output to {{log_path }}"
+    - name: "Save command output starting remaining Publisher to {{log_path }}"
       aws_s3:
         mode: get
         bucket: "{{ s3.bucket }}"
@@ -862,7 +862,7 @@
         - "{{ s3_files_start_remain_publish }}"
       when: error_start_remain_publish is defined or general_error is defined
 
-    - name: "Find error log files in {{log_path }}{{dl_path_stop_author_standby}}"
+    - name: "Find error log files of stopping Author Standby Service"
       find:
         paths: "{{log_path }}{{ dl_path_stop_author_standby }}"
         file_type: file
@@ -871,7 +871,7 @@
       register: stderr_stop_author_standby
       when: error_stop_author_standby is defined or general_error is defined
 
-    - name: "Find error log files in {{log_path }}{{dl_path_stop_author_primary}}"
+    - name: "Find error log files of stopping Author Primary Service"
       find:
         paths: "{{log_path }}{{ dl_path_stop_author_primary }}"
         file_type: file
@@ -880,7 +880,7 @@
       register: stderr_stop_author_primary
       when: error_stop_author_primary is defined or general_error is defined
 
-    - name: "Find error log files in {{log_path }}{{dl_path_stop_publish}}"
+    - name: "Find error log files of stopping Publish Service"
       find:
         paths: "{{log_path }}{{ dl_path_stop_publish }}"
         file_type: file
@@ -889,7 +889,7 @@
       register: stderr_stop_publish
       when: error_stop_publish is defined or general_error is defined
 
-    - name: "Find error log files in {{log_path }}{{dl_path_offline_compaction}}"
+    - name: "Find error log files of taking offline compaction"
       find:
         paths: "{{log_path }}{{ dl_path_offline_compaction }}"
         file_type: file
@@ -898,7 +898,7 @@
       register: stderr_offline_compaction
       when: error_offline_compaction is defined or general_error is defined
 
-    - name: "Find error log files in {{log_path }}{{dl_path_offline_backup}}"
+    - name: "Find error log files of taking offline backup"
       find:
         paths: "{{log_path }}{{ dl_path_offline_backup }}"
         file_type: file
@@ -907,7 +907,7 @@
       register: stderr_offline_backup
       when: error_offline_snapshot is defined or general_error is defined
 
-    - name: "Find error log files in {{log_path }}{{dl_path_start_author_primary}}"
+    - name: "Find error log files of starting Author Primary Service"
       find:
         paths: "{{log_path }}{{ dl_path_start_author_primary }}"
         file_type: file
@@ -916,7 +916,7 @@
       register: stderr_start_author_primary
       when: error_start_author_primary is defined or general_error is defined
 
-    - name: "Find error log files in {{log_path }}{{dl_path_start_author_standby}}"
+    - name: "Find error log files of starting Author Standby Service"
       find:
         paths: "{{log_path }}{{ dl_path_start_author_standby }}"
         file_type: file
@@ -925,7 +925,7 @@
       register: stderr_start_author_standby
       when: error_start_author_standby is defined or general_error is defined
 
-    - name: "Find error log files in {{log_path }}{{dl_path_start_publish}}"
+    - name: "Find error log files of starting Publish Service"
       find:
         paths: "{{log_path }}{{ dl_path_start_publish }}"
         file_type: file
@@ -934,7 +934,7 @@
       register: stderr_path_start_publish
       when: error_start_publish is defined or general_error is defined
 
-    - name: "Find error log files in {{log_path }}{{dl_path_remain_compact_jobs}}"
+    - name: "Find error log files of checking for remaining compaction jobs"
       find:
         paths: "{{log_path }}{{ dl_path_remain_compact_jobs }}"
         file_type: file
@@ -943,7 +943,7 @@
       register: stderr_path_remain_compact_jobs
       when: error_remain_compact_jobs is defined or general_error is defined
 
-    - name: "Find error log files in {{log_path }}{{dl_path_stop_remain_publish}}"
+    - name: "Find error log files of stopping remaining Publisher"
       find:
         paths: "{{log_path }}{{ dl_path_stop_remain_publish }}"
         file_type: file
@@ -952,7 +952,7 @@
       register: stderr_path_stop_remain_publish
       when: error_stop_remain_publish is defined or general_error is defined
 
-    - name: "Find error log files in {{log_path }}{{dl_path_compact_publish}}"
+    - name: "Find error log files of taking remaining offline compaction"
       find:
         paths: "{{log_path }}{{ dl_path_compact_publish }}"
         file_type: file
@@ -961,7 +961,7 @@
       register: stderr_path_compact_publish
       when: error_remain_compact_publish is defined or general_error is defined
 
-    - name: "Find error log files in {{log_path }}{{dl_path_start_remain_publish}}"
+    - name: "Find error log files of starting remaining Publisher"
       find:
         paths: "{{log_path }}{{ dl_path_start_remain_publish }}"
         file_type: file
@@ -970,84 +970,96 @@
       register: stderr_path_start_remain_publish
       when: error_start_remain_publish is defined or general_error is defined
 
-    - log_output:
+    - name: "Show Error Log of stopping Author Standby Service"
+      log_output:
         type: file
         log_files: "{{ item.files | map(attribute='path')|list }}"
       with_items:
         - "{{stderr_stop_author_standby}}"
       when: error_stop_author_standby is defined or general_error is defined
 
-    - log_output:
+    - name: "Show Error Log of stopping Author Primary Service"
+      log_output:
         type: file
         log_files: "{{ item.files | map(attribute='path')|list }}"
       with_items:
         - "{{stderr_stop_author_primary}}"
       when: error_stop_author_primary is defined or general_error is defined
 
-    - log_output:
+    - name: "Show Error Log of stopping Publish Service"
+      log_output:
         type: file
         log_files: "{{ item.files | map(attribute='path')|list }}"
       with_items:
         - "{{stderr_stop_publish}}"
       when: error_stop_publish is defined or general_error is defined
 
-    - log_output:
+    - name: "Show Error Log of taking offline compaction"
+      log_output:
         type: file
         log_files: "{{ item.files | map(attribute='path')|list }}"
       with_items:
         - "{{stderr_offline_compaction}}"
       when: error_offline_compaction is defined or general_error is defined
 
-    - log_output:
+    - name: "Show Error Log of taking offline backup"
+      log_output:
         type: file
         log_files: "{{ item.files | map(attribute='path')|list }}"
       with_items:
         - "{{stderr_offline_backup}}"
       when: error_offline_snapshot is defined or general_error is defined
 
-    - log_output:
+    - name: "Show Error Log of starting Author Primary Service"
+      log_output:
         type: file
         log_files: "{{ item.files | map(attribute='path')|list }}"
       with_items:
         - "{{stderr_start_author_primary}}"
       when: error_start_author_primary is defined or general_error is defined
 
-    - log_output:
+    - name: "Show Error Log of starting Author Standby Service"
+      log_output:
         type: file
         log_files: "{{ item.files | map(attribute='path')|list }}"
       with_items:
         - "{{stderr_start_author_standby}}"
       when: error_start_author_standby is defined or general_error is defined
 
-    - log_output:
+    - name: "Show Error Log of starting Publish Service"
+      log_output:
         type: file
         log_files: "{{ item.files | map(attribute='path')|list }}"
       with_items:
         - "{{stderr_path_start_publish}}"
       when: error_start_publish is defined or general_error is defined
 
-    - log_output:
+    - name: "Show Error Log of checking remaining compaction jobs"
+      log_output:
         type: file
         log_files: "{{ item.files | map(attribute='path')|list }}"
       with_items:
         - "{{stderr_path_remain_compact_jobs}}"
       when: error_remain_compact_jobs is defined or general_error is defined
 
-    - log_output:
+    - name: "Show Error Log of stopping remaining Publisher"
+      log_output:
         type: file
         log_files: "{{ item.files | map(attribute='path')|list }}"
       with_items:
         - "{{stderr_path_stop_remain_publish}}"
       when: error_stop_remain_publish is defined or general_error is defined
 
-    - log_output:
+    - name: "Show Error Log of taking remaining offline compaction"
+      log_output:
         type: file
         log_files: "{{ item.files | map(attribute='path')|list }}"
       with_items:
         - "{{stderr_path_compact_publish}}"
       when: error_remain_compact_publish is defined or general_error is defined
 
-    - log_output:
+    - name: "Show Error Log of starting remaining Publisher"
+      log_output:
         type: file
         log_files: "{{ item.files | map(attribute='path')|list }}"
       with_items:

--- a/offline-compaction-snapshot.yaml
+++ b/offline-compaction-snapshot.yaml
@@ -480,7 +480,7 @@
         bucket: "{{ s3.bucket }}"
         prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_stop_author_standby }}"
       register: output_files_stop_author_standby
-      When: cmd_id_stop_author_standby is defined
+      when: cmd_id_stop_author_standby is defined
 
     - name: Get path to output files of stopping Author Primary Service
       aws_s3:
@@ -488,7 +488,7 @@
         bucket: "{{ s3.bucket }}"
         prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_stop_author_primary }}"
       register: output_files_stop_author_primary
-      When: cmd_id_stop_author_primary is defined
+      when: cmd_id_stop_author_primary is defined
 
     - name: Get path to output files of stopping Publish Service
       aws_s3:
@@ -496,7 +496,7 @@
         bucket: "{{ s3.bucket }}"
         prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_stop_publish }}"
       register: output_files_stop_publish
-      When: cmd_id_stop_publish is defined
+      when: cmd_id_stop_publish is defined
 
     - name: Get path to output files of taking offline compaction
       aws_s3:
@@ -504,7 +504,7 @@
         bucket: "{{ s3.bucket }}"
         prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_offline_compaction }}"
       register: output_files_offline_compaction
-      When: cmd_id_offline_compaction is defined
+      when: cmd_id_offline_compaction is defined
 
     - name: Get path to output files of taking offline backup
       aws_s3:
@@ -512,7 +512,7 @@
         bucket: "{{ s3.bucket }}"
         prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_offline_backup }}"
       register: output_files_offline_backup
-      When: cmd_id_offline_backup is defined
+      when: cmd_id_offline_backup is defined
 
     - name: Get path to output files of starting Author Primary Service
       aws_s3:
@@ -520,7 +520,7 @@
         bucket: "{{ s3.bucket }}"
         prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_start_author_primary }}"
       register: output_files_start_author_primary
-      When: cmd_id_start_author_primary is defined
+      when: cmd_id_start_author_primary is defined
 
     - name: Get path to output files of starting Author Standby Service
       aws_s3:
@@ -528,7 +528,7 @@
         bucket: "{{ s3.bucket }}"
         prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_start_author_standby }}"
       register: output_files_start_author_standby
-      When: cmd_id_start_author_standby is defined
+      when: cmd_id_start_author_standby is defined
 
     - name: Get path to output files of starting Publish Service
       aws_s3:
@@ -536,7 +536,7 @@
         bucket: "{{ s3.bucket }}"
         prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_start_publish }}"
       register: output_files_start_publish
-      When: cmd_id_start_publish is defined
+      when: cmd_id_start_publish is defined
 
     - name: Get path to output files of checking remaining compaction jobs
       aws_s3:
@@ -544,7 +544,7 @@
         bucket: "{{ s3.bucket }}"
         prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_remain_compact_jobs }}"
       register: output_files_remain_compact_jobs
-      When: cmd_id_remain_compact_jobs is defined
+      when: cmd_id_remain_compact_jobs is defined
 
     - name: Get path to output files of stopping remaining publisher
       aws_s3:
@@ -552,7 +552,7 @@
         bucket: "{{ s3.bucket }}"
         prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_stop_remain_publish }}"
       register: output_files_stop_remain_publish
-      When: cmd_id_stop_remain_publish is defined
+      when: cmd_id_stop_remain_publish is defined
 
     - name: Get path to output files of compact remaining publisher
       aws_s3:
@@ -560,7 +560,7 @@
         bucket: "{{ s3.bucket }}"
         prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_compact_publish }}"
       register: output_files_compact_publish
-      When: cmd_id_compact_publish is defined
+      when: cmd_id_compact_publish is defined
 
     - name: Get path to output files of starting remaining publisher
       aws_s3:
@@ -568,7 +568,7 @@
         bucket: "{{ s3.bucket }}"
         prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_start_remain_publish }}"
       register: output_files_start_remain_publish
-      When: cmd_id_start_remain_publish is defined
+      when: cmd_id_start_remain_publish is defined
 
     - name: Set global facts for getting command output
       set_fact:

--- a/offline-compaction-snapshot.yaml
+++ b/offline-compaction-snapshot.yaml
@@ -23,7 +23,7 @@
         region: "{{ aws_region }}"
       register: publish_message
 
-    - name: Scan if author standby instance is stopped
+    - name: Scan if Author Standby Service is stopped
       dynamodb_search:
         table_name: "{{ dynamodb_tablename }}"
         attribute: message_id
@@ -42,7 +42,24 @@
       with_items:
         "{{ cmd_stop_author_standby.item }}"
 
-    - name: Scan if author primary instance is stopped
+    - name: Query if Author Standby Service successfully stopped
+      dynamodb_search:
+        table_name: "{{ dynamodb_tablename }}"
+        attribute: command_id
+        attribute_value: "{{ cmd_id_stop_author_standby }}"
+        get_attribute: state
+        select: SPECIFIC_ATTRIBUTES
+        comparisonoperator: EQ
+        state: query
+      register: dbquery_state_stop_author_standby
+
+    - name: Check for error
+      set_fact:
+        error_stop_author_standby: 1
+        module_error: 1
+      when: dbquery_state_stop_author_standby.item[0].state.S == "Failed"
+
+    - name: Scan if Author Primary Service is stopped
       dynamodb_search:
         table_name: "{{ dynamodb_tablename }}"
         attribute: last_command
@@ -61,7 +78,24 @@
       with_items:
         "{{ cmd_stop_author_primary.item }}"
 
-    - name: Scan if publish instance is stopped
+    - name: Query if Author Primary Service successfully stopped
+      dynamodb_search:
+        table_name: "{{ dynamodb_tablename }}"
+        attribute: command_id
+        attribute_value: "{{ cmd_id_stop_author_primary }}"
+        get_attribute: state
+        select: SPECIFIC_ATTRIBUTES
+        comparisonoperator: EQ
+        state: query
+      register: dbquery_state_stop_author_primary
+
+    - name: Check for error
+      set_fact:
+        error_stop_author_primary: 1
+        module_error: 1
+      when: dbquery_state_stop_author_primary.item[0].state.S == "Failed"
+
+    - name: Scan if Publish Services are stopped
       dynamodb_search:
         table_name: "{{ dynamodb_tablename }}"
         attribute: last_command
@@ -79,6 +113,23 @@
         cmd_id_stop_publish: "{{ item.command_id.S }}"
       with_items:
         "{{ cmd_stop_publish.item }}"
+
+    - name: Query if Publish Services are successfully stopped
+      dynamodb_search:
+        table_name: "{{ dynamodb_tablename }}"
+        attribute: command_id
+        attribute_value: "{{ cmd_id_stop_publish }}"
+        get_attribute: state
+        select: SPECIFIC_ATTRIBUTES
+        comparisonoperator: EQ
+        state: query
+      register: dbquery_state_stop_publish
+
+    - name: Check for error
+      set_fact:
+        error_stop_publish: 1
+        module_error: 1
+      when: dbquery_state_stop_publish.item[0].state.S == "Failed"
 
     - name: Scan if offline-compaction finished
       dynamodb_search:
@@ -99,6 +150,23 @@
       with_items:
         "{{ cmd_offline_compaction.item }}"
 
+    - name: Query Offline-Compaction was successful
+      dynamodb_search:
+        table_name: "{{ dynamodb_tablename }}"
+        attribute: command_id
+        attribute_value: "{{ cmd_id_offline_compaction }}"
+        get_attribute: state
+        select: SPECIFIC_ATTRIBUTES
+        comparisonoperator: EQ
+        state: query
+      register: dbquery_state_offline_compaction
+
+    - name: Check for error
+      set_fact:
+        error_offline_compaction: 1
+        module_error: 1
+      when: dbquery_state_offline_compaction.item[0].state.S == "Failed"
+
     - name: Scan if offline-backup is executed
       dynamodb_search:
         table_name: "{{ dynamodb_tablename }}"
@@ -118,7 +186,24 @@
       with_items:
         "{{ cmd_offline_backup.item }}"
 
-    - name: Scan if author primary instance is started
+    - name: Query Offline-Snapshot was successful
+      dynamodb_search:
+        table_name: "{{ dynamodb_tablename }}"
+        attribute: command_id
+        attribute_value: "{{ cmd_id_offline_backup }}"
+        get_attribute: state
+        select: SPECIFIC_ATTRIBUTES
+        comparisonoperator: EQ
+        state: query
+      register: dbquery_state_offline_snapshot
+
+    - name: Check for error
+      set_fact:
+        error_offline_snapshot: 1
+        module_error: 1
+      when: dbquery_state_offline_snapshot.item[0].state.S == "Failed"
+
+    - name: Scan if Author Primary Service is started
       dynamodb_search:
         table_name: "{{ dynamodb_tablename }}"
         attribute: last_command
@@ -136,6 +221,23 @@
         cmd_id_start_author_primary: "{{ item.command_id.S }}"
       with_items:
         "{{ cmd_start_author_primary.item }}"
+
+    - name: Query if starting Author Primary Service was successful
+      dynamodb_search:
+        table_name: "{{ dynamodb_tablename }}"
+        attribute: command_id
+        attribute_value: "{{ cmd_id_start_author_primary }}"
+        get_attribute: state
+        select: SPECIFIC_ATTRIBUTES
+        comparisonoperator: EQ
+        state: query
+      register: dbquery_state_start_author_primary
+
+    - name: Check for error
+      set_fact:
+        error_start_author_primary: 1
+        module_error: 1
+      when: dbquery_state_start_author_primary.item[0].state.S == "Failed"
 
     - name: Scan if author standby instance is started
       dynamodb_search:
@@ -156,6 +258,23 @@
       with_items:
         "{{ cmd_start_author_standby.item }}"
 
+    - name: Query if starting Author Standby Service was successful
+      dynamodb_search:
+        table_name: "{{ dynamodb_tablename }}"
+        attribute: command_id
+        attribute_value: "{{ cmd_id_start_author_standby }}"
+        get_attribute: state
+        select: SPECIFIC_ATTRIBUTES
+        comparisonoperator: EQ
+        state: query
+      register: dbquery_state_start_author_standby
+
+    - name: Check for error
+      set_fact:
+        error_start_author_standby: 1
+        module_error: 1
+      when: dbquery_state_start_author_standby.item[0].state.S == "Failed"
+
     - name: Scan if publish instance is started
       dynamodb_search:
         table_name: "{{ dynamodb_tablename }}"
@@ -174,6 +293,23 @@
         cmd_id_start_publish: "{{ item.command_id.S }}"
       with_items:
         "{{ cmd_start_publish.item }}"
+
+    - name: Query if starting Publish Services were successful
+      dynamodb_search:
+        table_name: "{{ dynamodb_tablename }}"
+        attribute: command_id
+        attribute_value: "{{ cmd_id_start_publish }}"
+        get_attribute: state
+        select: SPECIFIC_ATTRIBUTES
+        comparisonoperator: EQ
+        state: query
+      register: dbquery_state_start_publish
+
+    - name: Check for error
+      set_fact:
+        error_start_publish: 1
+        module_error: 1
+      when: dbquery_state_start_publish.item[0].state.S == "Failed"
 
     - name: Scan if job remaining compact jobs are finished
       dynamodb_search:
@@ -194,6 +330,23 @@
       with_items:
         "{{ cmd_remain_compact_jobs.item }}"
 
+    - name: Query if remaining compact jobs are finished
+      dynamodb_search:
+        table_name: "{{ dynamodb_tablename }}"
+        attribute: command_id
+        attribute_value: "{{ cmd_id_remain_compact_jobs }}"
+        get_attribute: state
+        select: SPECIFIC_ATTRIBUTES
+        comparisonoperator: EQ
+        state: query
+      register: dbquery_remain_compact_jobs
+
+    - name: Check for error
+      set_fact:
+        error_remain_compact_jobs: 1
+        module_error: 1
+      when: dbquery_remain_compact_jobs.item[0].state.S == "Failed"
+
     - name: Scan if remaining publish instances are stopped
       dynamodb_search:
         table_name: "{{ dynamodb_tablename }}"
@@ -212,6 +365,23 @@
         cmd_id_stop_remain_publish: "{{ item.command_id.S }}"
       with_items:
         "{{ cmd_stop_remain_publish.item }}"
+
+    - name: Query if stopping remaining Publish Services was successful
+      dynamodb_search:
+        table_name: "{{ dynamodb_tablename }}"
+        attribute: command_id
+        attribute_value: "{{ cmd_id_stop_remain_publish }}"
+        get_attribute: state
+        select: SPECIFIC_ATTRIBUTES
+        comparisonoperator: EQ
+        state: query
+      register: dbquery_stop_remain_publish
+
+    - name: Check for error
+      set_fact:
+        error_stop_remain_publish: 1
+        module_error: 1
+      when: dbquery_stop_remain_publish.item[0].state.S == "Failed"
 
     - name: Scan if remaining publish instances are compacted
       dynamodb_search:
@@ -232,6 +402,23 @@
       with_items:
         "{{ cmd_compact_publish.item }}"
 
+    - name: Query if remaining Publish Instances are compacted successful
+      dynamodb_search:
+        table_name: "{{ dynamodb_tablename }}"
+        attribute: command_id
+        attribute_value: "{{ cmd_id_compact_publish }}"
+        get_attribute: state
+        select: SPECIFIC_ATTRIBUTES
+        comparisonoperator: EQ
+        state: query
+      register: dbquery_compact_publish
+
+    - name: Check for error
+      set_fact:
+        error_remain_compact_publish: 1
+        module_error: 1
+      when: dbquery_compact_publish.item[0].state.S == "Failed"
+
     - name: Scan if remaining publish instances are started
       dynamodb_search:
         table_name: "{{ dynamodb_tablename }}"
@@ -251,6 +438,23 @@
       with_items:
         "{{ cmd_start_remain_publish.item }}"
 
+    - name: Query if start remaining remaining Publish Services were successful
+      dynamodb_search:
+        table_name: "{{ dynamodb_tablename }}"
+        attribute: command_id
+        attribute_value: "{{ cmd_id_start_remain_publish }}"
+        get_attribute: state
+        select: SPECIFIC_ATTRIBUTES
+        comparisonoperator: EQ
+        state: query
+      register: dbquery_start_remain_publish
+
+    - name: Check for error
+      set_fact:
+        error_start_remain_publish: 1
+        module_error: 1
+      when: dbquery_start_remain_publish.item[0].state.S == "Failed"
+
     - name: Query if offline-compaction-snapshot was successful
       dynamodb_search:
         table_name: "{{ dynamodb_tablename }}"
@@ -265,12 +469,18 @@
       retries:  720
       delay: 5
 
+    - name: Check if offline-compaction-snapshot failed
+      set_fact:
+        general_error: 1
+      when: dbquery.item[0].state.S == "Failed"
+
     - name: Get path to output files
       aws_s3:
         mode: list
         bucket: "{{ s3.bucket }}"
         prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_stop_author_standby }}"
       register: output_files_stop_author_standby
+      When: cmd_id_stop_author_standby is defined
 
     - name: Get path to output files
       aws_s3:
@@ -278,6 +488,7 @@
         bucket: "{{ s3.bucket }}"
         prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_stop_author_primary }}"
       register: output_files_stop_author_primary
+      When: cmd_id_stop_author_primary is defined
 
     - name: Get path to output files
       aws_s3:
@@ -285,6 +496,7 @@
         bucket: "{{ s3.bucket }}"
         prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_stop_publish }}"
       register: output_files_stop_publish
+      When: cmd_id_stop_publish is defined
 
     - name: Get path to output files
       aws_s3:
@@ -292,6 +504,7 @@
         bucket: "{{ s3.bucket }}"
         prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_offline_compaction }}"
       register: output_files_offline_compaction
+      When: cmd_id_offline_compaction is defined
 
     - name: Get path to output files
       aws_s3:
@@ -299,6 +512,7 @@
         bucket: "{{ s3.bucket }}"
         prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_offline_backup }}"
       register: output_files_offline_backup
+      When: cmd_id_offline_backup is defined
 
     - name: Get path to output files
       aws_s3:
@@ -306,6 +520,7 @@
         bucket: "{{ s3.bucket }}"
         prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_start_author_primary }}"
       register: output_files_start_author_primary
+      When: cmd_id_start_author_primary is defined
 
     - name: Get path to output files
       aws_s3:
@@ -313,6 +528,7 @@
         bucket: "{{ s3.bucket }}"
         prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_start_author_standby }}"
       register: output_files_start_author_standby
+      When: cmd_id_start_author_standby is defined
 
     - name: Get path to output files
       aws_s3:
@@ -320,6 +536,7 @@
         bucket: "{{ s3.bucket }}"
         prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_start_publish }}"
       register: output_files_start_publish
+      When: cmd_id_start_publish is defined
 
     - name: Get path to output files
       aws_s3:
@@ -327,6 +544,7 @@
         bucket: "{{ s3.bucket }}"
         prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_remain_compact_jobs }}"
       register: output_files_remain_compact_jobs
+      When: cmd_id_remain_compact_jobs is defined
 
     - name: Get path to output files
       aws_s3:
@@ -334,6 +552,7 @@
         bucket: "{{ s3.bucket }}"
         prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_stop_remain_publish }}"
       register: output_files_stop_remain_publish
+      When: cmd_id_stop_remain_publish is defined
 
     - name: Get path to output files
       aws_s3:
@@ -341,6 +560,7 @@
         bucket: "{{ s3.bucket }}"
         prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_compact_publish }}"
       register: output_files_compact_publish
+      When: cmd_id_compact_publish is defined
 
     - name: Get path to output files
       aws_s3:
@@ -348,34 +568,83 @@
         bucket: "{{ s3.bucket }}"
         prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_start_remain_publish }}"
       register: output_files_start_remain_publish
+      When: cmd_id_start_remain_publish is defined
 
-    - name: Set facts for getting command output
+    - name: Set global facts for getting command output
       set_fact:
         log_path: "{{ playbook_dir }}/logs/"
+
+    - name: Set facts for getting command output stop Author Standby Service
+      set_fact:
         dl_path_stop_author_standby: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_stop_author_standby }}"
-        dl_path_stop_author_primary: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_stop_author_primary }}"
-        dl_path_stop_publish: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_stop_publish }}"
-        dl_path_offline_compaction: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{cmd_id_offline_compaction}}"
-        dl_path_offline_backup: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_offline_backup }}"
-        dl_path_start_author_primary: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_start_author_primary }}"
-        dl_path_start_author_standby: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_start_author_standby }}"
-        dl_path_start_publish: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_start_publish }}"
-        dl_path_remain_compact_jobs: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{cmd_id_remain_compact_jobs}}"
-        dl_path_stop_remain_publish: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{cmd_id_stop_remain_publish}}"
-        dl_path_compact_publish: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{cmd_id_compact_publish}}"
-        dl_path_start_remain_publish: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{cmd_id_start_remain_publish}}"
         s3_files_stop_author_standby: "{{ output_files_stop_author_standby.s3_keys }}"
+      when: error_stop_author_standby is defined or general_error is defined
+
+    - name: Set facts for getting command output stop Author Primary Service
+      set_fact:
+        dl_path_stop_author_primary: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_stop_author_primary }}"
         s3_files_stop_author_primary: "{{ output_files_stop_author_primary.s3_keys }}"
+      when: error_stop_author_primary is defined or general_error is defined
+
+    - name: Set facts for getting command output stop Publish Services
+      set_fact:
+        dl_path_stop_publish: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_stop_publish }}"
         s3_files_stop_publish: "{{ output_files_stop_publish.s3_keys }}"
+      when: error_stop_publish is defined or general_error is defined
+
+    - name: Set facts for getting command output Offline Compaction
+      set_fact:
+        dl_path_offline_compaction: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{cmd_id_offline_compaction}}"
         s3_files_offline_compaction: "{{ output_files_offline_compaction.s3_keys }}"
+      when: error_offline_compaction is defined or general_error is defined
+
+    - name: Set facts for getting command output Offline Backup
+      set_fact:
+        dl_path_offline_backup: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_offline_backup }}"
         s3_files_offline_backup: "{{ output_files_offline_backup.s3_keys }}"
+      when: error_offline_snapshot is defined or general_error is defined
+
+    - name: Set facts for getting command output start Author Primary Service
+      set_fact:
+        dl_path_start_author_primary: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_start_author_primary }}"
         s3_files_start_author_primary: "{{ output_files_start_author_primary.s3_keys }}"
+      when: error_start_author_primary is defined or general_error is defined
+
+    - name: Set facts for getting command output start Author Standby Service
+      set_fact:
+        dl_path_start_author_standby: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_start_author_standby }}"
         s3_files_start_author_standby: "{{ output_files_start_author_standby.s3_keys }}"
+      when: error_start_author_standby is defined or general_error is defined
+
+    - name: Set facts for getting command output start Publish Services
+      set_fact:
+        dl_path_start_publish: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_start_publish }}"
         s3_files_start_publish: "{{ output_files_start_publish.s3_keys }}"
+      when: error_start_publish is defined or general_error is defined
+
+    - name: Set facts for getting command output remaining compact jobs
+      set_fact:
+        dl_path_remain_compact_jobs: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{cmd_id_remain_compact_jobs}}"
         s3_files_remain_compact_jobs: "{{ output_files_remain_compact_jobs.s3_keys }}"
+      when: error_remain_compact_jobs is defined or general_error is defined
+
+    - name: Set facts for getting command output stop remaining Publish Services
+      set_fact:
+        dl_path_stop_remain_publish: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{cmd_id_stop_remain_publish}}"
         s3_files_stop_remain_publish: "{{ output_files_stop_remain_publish.s3_keys }}"
+      when: error_stop_remain_publish is defined or general_error is defined
+
+    - name: Set facts for getting command output compact remaining publisher
+      set_fact:
+        dl_path_compact_publish: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{cmd_id_compact_publish}}"
         s3_files_compact_publish: "{{ output_files_compact_publish.s3_keys }}"
+      when: error_remain_compact_publish is defined or general_error is defined
+
+    - name: Set facts for getting command output start remaining Publish Servvice
+      set_fact:
+        dl_path_start_remain_publish: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{cmd_id_start_remain_publish}}"
         s3_files_start_remain_publish: "{{ output_files_start_remain_publish.s3_keys }}"
+      when: error_start_remain_publish is defined or general_error is defined
 
     - name: "Create Download directory"
       file:
@@ -383,18 +652,95 @@
         state: directory
       with_items:
         - "{{ s3_files_stop_author_standby }}"
+      when: error_stop_author_standby is defined or general_error is defined
+
+    - name: "Create Download directory"
+      file:
+        path: "{{ log_path }}{{ item|regex_replace('(stdout|stderr)$', '') }}"
+        state: directory
+      with_items:
         - "{{ s3_files_stop_author_primary }}"
-        - "{{ s3_files_stop_author_standby }}"
+      when: error_stop_author_primary is defined or general_error is defined
+
+    - name: "Create Download directory"
+      file:
+        path: "{{ log_path }}{{ item|regex_replace('(stdout|stderr)$', '') }}"
+        state: directory
+      with_items:
         - "{{ s3_files_stop_publish }}"
-        - "{{ s3_files_offline_compaction }}"
-        - "{{ s3_files_offline_backup }}"
-        - "{{ s3_files_start_author_primary }}"
-        - "{{ s3_files_start_author_standby }}"
-        - "{{ s3_files_start_publish }}"
-        - "{{ s3_files_remain_compact_jobs }}"
-        - "{{ s3_files_stop_remain_publish }}"
-        - "{{ s3_files_compact_publish }}"
-        - "{{ s3_files_start_remain_publish }}"
+      when: error_stop_publish is defined or general_error is defined
+
+    - name: "Create Download directory"
+      file:
+        path: "{{ log_path }}{{ item|regex_replace('(stdout|stderr)$', '') }}"
+        state: directory
+      with_items:
+      - "{{ s3_files_offline_compaction }}"
+      when: error_offline_compaction is defined or general_error is defined
+
+    - name: "Create Download directory"
+      file:
+        path: "{{ log_path }}{{ item|regex_replace('(stdout|stderr)$', '') }}"
+        state: directory
+      with_items:
+      - "{{ s3_files_offline_backup }}"
+      when: error_offline_snapshot is defined or general_error is defined
+
+    - name: "Create Download directory"
+      file:
+        path: "{{ log_path }}{{ item|regex_replace('(stdout|stderr)$', '') }}"
+        state: directory
+      with_items:
+      - "{{ s3_files_start_author_primary }}"
+      when: error_start_author_primary is defined or general_error is defined
+
+    - name: "Create Download directory"
+      file:
+        path: "{{ log_path }}{{ item|regex_replace('(stdout|stderr)$', '') }}"
+        state: directory
+      with_items:
+      - "{{ s3_files_start_author_standby }}"
+      when: error_start_author_standby is defined or general_error is defined
+
+    - name: "Create Download directory"
+      file:
+        path: "{{ log_path }}{{ item|regex_replace('(stdout|stderr)$', '') }}"
+        state: directory
+      with_items:
+      - "{{ s3_files_start_publish }}"
+      when: error_start_publish is defined or general_error is defined
+
+    - name: "Create Download directory"
+      file:
+        path: "{{ log_path }}{{ item|regex_replace('(stdout|stderr)$', '') }}"
+        state: directory
+      with_items:
+      - "{{ s3_files_remain_compact_jobs }}"
+      when: error_remain_compact_jobs is defined or general_error is defined
+
+    - name: "Create Download directory"
+      file:
+        path: "{{ log_path }}{{ item|regex_replace('(stdout|stderr)$', '') }}"
+        state: directory
+      with_items:
+      - "{{ s3_files_stop_remain_publish }}"
+      when: error_stop_remain_publish is defined or general_error is defined
+
+    - name: "Create Download directory"
+      file:
+        path: "{{ log_path }}{{ item|regex_replace('(stdout|stderr)$', '') }}"
+        state: directory
+      with_items:
+      - "{{ s3_files_compact_publish }}"
+      when: error_remain_compact_publish is defined or general_error is defined
+
+    - name: "Create Download directory"
+      file:
+        path: "{{ log_path }}{{ item|regex_replace('(stdout|stderr)$', '') }}"
+        state: directory
+      with_items:
+      - "{{ s3_files_start_remain_publish }}"
+      when: error_start_remain_publish is defined or general_error is defined
 
     - name: "Save command output to {{log_path }}"
       aws_s3:
@@ -404,18 +750,117 @@
         dest: "{{ log_path }}{{ item }}"
       with_items:
         - "{{ s3_files_stop_author_standby }}"
+      when: error_stop_author_standby is defined or general_error is defined
+
+    - name: "Save command output to {{log_path }}"
+      aws_s3:
+        mode: get
+        bucket: "{{ s3.bucket }}"
+        object: "{{ item }}"
+        dest: "{{ log_path }}{{ item }}"
+      with_items:
         - "{{ s3_files_stop_author_primary }}"
-        - "{{ s3_files_stop_author_standby }}"
+      when: error_stop_author_primary is defined or general_error is defined
+
+    - name: "Save command output to {{log_path }}"
+      aws_s3:
+        mode: get
+        bucket: "{{ s3.bucket }}"
+        object: "{{ item }}"
+        dest: "{{ log_path }}{{ item }}"
+      with_items:
         - "{{ s3_files_stop_publish }}"
+      when: error_stop_publish is defined or general_error is defined
+
+    - name: "Save command output to {{log_path }}"
+      aws_s3:
+        mode: get
+        bucket: "{{ s3.bucket }}"
+        object: "{{ item }}"
+        dest: "{{ log_path }}{{ item }}"
+      with_items:
         - "{{ s3_files_offline_compaction }}"
+      when: error_offline_compaction is defined or general_error is defined
+
+    - name: "Save command output to {{log_path }}"
+      aws_s3:
+        mode: get
+        bucket: "{{ s3.bucket }}"
+        object: "{{ item }}"
+        dest: "{{ log_path }}{{ item }}"
+      with_items:
         - "{{ s3_files_offline_backup }}"
+      when: error_offline_snapshot is defined or general_error is defined
+
+    - name: "Save command output to {{log_path }}"
+      aws_s3:
+        mode: get
+        bucket: "{{ s3.bucket }}"
+        object: "{{ item }}"
+        dest: "{{ log_path }}{{ item }}"
+      with_items:
         - "{{ s3_files_start_author_primary }}"
+      when: error_start_author_primary is defined or general_error is defined
+
+    - name: "Save command output to {{log_path }}"
+      aws_s3:
+        mode: get
+        bucket: "{{ s3.bucket }}"
+        object: "{{ item }}"
+        dest: "{{ log_path }}{{ item }}"
+      with_items:
         - "{{ s3_files_start_author_standby }}"
+      when: error_start_author_standby is defined or general_error is defined
+
+    - name: "Save command output to {{log_path }}"
+      aws_s3:
+        mode: get
+        bucket: "{{ s3.bucket }}"
+        object: "{{ item }}"
+        dest: "{{ log_path }}{{ item }}"
+      with_items:
         - "{{ s3_files_start_publish }}"
+      when: error_start_publish is defined or general_error is defined
+
+    - name: "Save command output to {{log_path }}"
+      aws_s3:
+        mode: get
+        bucket: "{{ s3.bucket }}"
+        object: "{{ item }}"
+        dest: "{{ log_path }}{{ item }}"
+      with_items:
         - "{{ s3_files_remain_compact_jobs }}"
+      when: error_remain_compact_jobs is defined or general_error is defined
+
+    - name: "Save command output to {{log_path }}"
+      aws_s3:
+        mode: get
+        bucket: "{{ s3.bucket }}"
+        object: "{{ item }}"
+        dest: "{{ log_path }}{{ item }}"
+      with_items:
         - "{{ s3_files_stop_remain_publish }}"
+      when: error_stop_remain_publish is defined or general_error is defined
+
+    - name: "Save command output to {{log_path }}"
+      aws_s3:
+        mode: get
+        bucket: "{{ s3.bucket }}"
+        object: "{{ item }}"
+        dest: "{{ log_path }}{{ item }}"
+      with_items:
         - "{{ s3_files_compact_publish }}"
+      when: error_remain_compact_publish is defined or general_error is defined
+
+    - name: "Save command output to {{log_path }}"
+      aws_s3:
+        mode: get
+        bucket: "{{ s3.bucket }}"
+        object: "{{ item }}"
+        dest: "{{ log_path }}{{ item }}"
+      with_items:
         - "{{ s3_files_start_remain_publish }}"
+      when: error_start_remain_publish is defined or general_error is defined
 
     - name: "Find error log files in {{log_path }}{{dl_path_stop_author_standby}}"
       find:
@@ -424,6 +869,7 @@
         patterns: stderr
         recurse: yes
       register: stderr_stop_author_standby
+      when: error_stop_author_standby is defined or general_error is defined
 
     - name: "Find error log files in {{log_path }}{{dl_path_stop_author_primary}}"
       find:
@@ -432,6 +878,7 @@
         patterns: stderr
         recurse: yes
       register: stderr_stop_author_primary
+      when: error_stop_author_primary is defined or general_error is defined
 
     - name: "Find error log files in {{log_path }}{{dl_path_stop_publish}}"
       find:
@@ -440,6 +887,7 @@
         patterns: stderr
         recurse: yes
       register: stderr_stop_publish
+      when: error_stop_publish is defined or general_error is defined
 
     - name: "Find error log files in {{log_path }}{{dl_path_offline_compaction}}"
       find:
@@ -448,6 +896,7 @@
         patterns: stderr
         recurse: yes
       register: stderr_offline_compaction
+      when: error_offline_compaction is defined or general_error is defined
 
     - name: "Find error log files in {{log_path }}{{dl_path_offline_backup}}"
       find:
@@ -456,6 +905,7 @@
         patterns: stderr
         recurse: yes
       register: stderr_offline_backup
+      when: error_offline_snapshot is defined or general_error is defined
 
     - name: "Find error log files in {{log_path }}{{dl_path_start_author_primary}}"
       find:
@@ -464,6 +914,7 @@
         patterns: stderr
         recurse: yes
       register: stderr_start_author_primary
+      when: error_start_author_primary is defined or general_error is defined
 
     - name: "Find error log files in {{log_path }}{{dl_path_start_author_standby}}"
       find:
@@ -472,6 +923,7 @@
         patterns: stderr
         recurse: yes
       register: stderr_start_author_standby
+      when: error_start_author_standby is defined or general_error is defined
 
     - name: "Find error log files in {{log_path }}{{dl_path_start_publish}}"
       find:
@@ -480,6 +932,7 @@
         patterns: stderr
         recurse: yes
       register: stderr_path_start_publish
+      when: error_start_publish is defined or general_error is defined
 
     - name: "Find error log files in {{log_path }}{{dl_path_remain_compact_jobs}}"
       find:
@@ -488,6 +941,7 @@
         patterns: stderr
         recurse: yes
       register: stderr_path_remain_compact_jobs
+      when: error_remain_compact_jobs is defined or general_error is defined
 
     - name: "Find error log files in {{log_path }}{{dl_path_stop_remain_publish}}"
       find:
@@ -496,6 +950,7 @@
         patterns: stderr
         recurse: yes
       register: stderr_path_stop_remain_publish
+      when: error_stop_remain_publish is defined or general_error is defined
 
     - name: "Find error log files in {{log_path }}{{dl_path_compact_publish}}"
       find:
@@ -504,6 +959,7 @@
         patterns: stderr
         recurse: yes
       register: stderr_path_compact_publish
+      when: error_remain_compact_publish is defined or general_error is defined
 
     - name: "Find error log files in {{log_path }}{{dl_path_start_remain_publish}}"
       find:
@@ -512,20 +968,92 @@
         patterns: stderr
         recurse: yes
       register: stderr_path_start_remain_publish
+      when: error_start_remain_publish is defined or general_error is defined
 
     - log_output:
         type: file
         log_files: "{{ item.files | map(attribute='path')|list }}"
       with_items:
         - "{{stderr_stop_author_standby}}"
+      when: error_stop_author_standby is defined or general_error is defined
+
+    - log_output:
+        type: file
+        log_files: "{{ item.files | map(attribute='path')|list }}"
+      with_items:
         - "{{stderr_stop_author_primary}}"
+      when: error_stop_author_primary is defined or general_error is defined
+
+    - log_output:
+        type: file
+        log_files: "{{ item.files | map(attribute='path')|list }}"
+      with_items:
         - "{{stderr_stop_publish}}"
+      when: error_stop_publish is defined or general_error is defined
+
+    - log_output:
+        type: file
+        log_files: "{{ item.files | map(attribute='path')|list }}"
+      with_items:
         - "{{stderr_offline_compaction}}"
+      when: error_offline_compaction is defined or general_error is defined
+
+    - log_output:
+        type: file
+        log_files: "{{ item.files | map(attribute='path')|list }}"
+      with_items:
         - "{{stderr_offline_backup}}"
+      when: error_offline_snapshot is defined or general_error is defined
+
+    - log_output:
+        type: file
+        log_files: "{{ item.files | map(attribute='path')|list }}"
+      with_items:
         - "{{stderr_start_author_primary}}"
+      when: error_start_author_primary is defined or general_error is defined
+
+    - log_output:
+        type: file
+        log_files: "{{ item.files | map(attribute='path')|list }}"
+      with_items:
         - "{{stderr_start_author_standby}}"
+      when: error_start_author_standby is defined or general_error is defined
+
+    - log_output:
+        type: file
+        log_files: "{{ item.files | map(attribute='path')|list }}"
+      with_items:
         - "{{stderr_path_start_publish}}"
+      when: error_start_publish is defined or general_error is defined
+
+    - log_output:
+        type: file
+        log_files: "{{ item.files | map(attribute='path')|list }}"
+      with_items:
         - "{{stderr_path_remain_compact_jobs}}"
+      when: error_remain_compact_jobs is defined or general_error is defined
+
+    - log_output:
+        type: file
+        log_files: "{{ item.files | map(attribute='path')|list }}"
+      with_items:
         - "{{stderr_path_stop_remain_publish}}"
+      when: error_stop_remain_publish is defined or general_error is defined
+
+    - log_output:
+        type: file
+        log_files: "{{ item.files | map(attribute='path')|list }}"
+      with_items:
         - "{{stderr_path_compact_publish}}"
+      when: error_remain_compact_publish is defined or general_error is defined
+
+    - log_output:
+        type: file
+        log_files: "{{ item.files | map(attribute='path')|list }}"
+      with_items:
         - "{{stderr_path_start_remain_publish}}"
+      when: error_start_remain_publish is defined or general_error is defined
+
+    - fail:
+        msg: " Error while executing offline-compactions-snapshot"
+      when: general_error is defined or module_error is defined

--- a/offline-snapshot.yaml
+++ b/offline-snapshot.yaml
@@ -42,6 +42,23 @@
       with_items:
         "{{ cmd_stop_author_standby.item }}"
 
+    - name: Query if Author Standby Service successfully stopped
+      dynamodb_search:
+        table_name: "{{ dynamodb_tablename }}"
+        attribute: command_id
+        attribute_value: "{{ cmd_id_stop_author_standby }}"
+        get_attribute: state
+        select: SPECIFIC_ATTRIBUTES
+        comparisonoperator: EQ
+        state: query
+      register: dbquery_state_stop_author_standby
+
+    - name: Check for error when stopping Author Standby Service
+      set_fact:
+        error_stop_author_standby: 1
+        module_error: 1
+      when: dbquery_state_stop_author_standby.item[0].state.S == "Failed"
+
     - name: Scan if author primary instance is stopped
       dynamodb_search:
         table_name: "{{ dynamodb_tablename }}"
@@ -60,6 +77,23 @@
         cmd_id_stop_author_primary: "{{ item.command_id.S }}"
       with_items:
         "{{ cmd_stop_author_primary.item }}"
+
+    - name: Query if Author Primary Service successfully stopped
+      dynamodb_search:
+        table_name: "{{ dynamodb_tablename }}"
+        attribute: command_id
+        attribute_value: "{{ cmd_id_stop_author_primary }}"
+        get_attribute: state
+        select: SPECIFIC_ATTRIBUTES
+        comparisonoperator: EQ
+        state: query
+      register: dbquery_state_stop_author_primary
+
+    - name: Check for error when stopping Author Primary Service
+      set_fact:
+        error_stop_author_primary: 1
+        module_error: 1
+      when: dbquery_state_stop_author_primary.item[0].state.S == "Failed"
 
     - name: Scan if publish instance is stopped
       dynamodb_search:
@@ -80,6 +114,23 @@
       with_items:
         "{{ cmd_stop_publish.item }}"
 
+    - name: Query if Publish Services are successfully stopped
+      dynamodb_search:
+        table_name: "{{ dynamodb_tablename }}"
+        attribute: command_id
+        attribute_value: "{{ cmd_id_stop_publish }}"
+        get_attribute: state
+        select: SPECIFIC_ATTRIBUTES
+        comparisonoperator: EQ
+        state: query
+      register: dbquery_state_stop_publish
+
+    - name: Check for error when stopping Publish Service
+      set_fact:
+        error_stop_publish: 1
+        module_error: 1
+      when: dbquery_state_stop_publish.item[0].state.S == "Failed"
+
     - name: Scan if offline-backup is executed
       dynamodb_search:
         table_name: "{{ dynamodb_tablename }}"
@@ -98,6 +149,23 @@
         cmd_id_offline_backup: "{{ item.command_id.S }}"
       with_items:
         "{{ cmd_offline_backup.item }}"
+
+    - name: Query Offline-Snapshot was successful
+      dynamodb_search:
+        table_name: "{{ dynamodb_tablename }}"
+        attribute: command_id
+        attribute_value: "{{ cmd_id_offline_backup }}"
+        get_attribute: state
+        select: SPECIFIC_ATTRIBUTES
+        comparisonoperator: EQ
+        state: query
+      register: dbquery_state_offline_snapshot
+
+    - name: Check for error when taking offline backup
+      set_fact:
+        error_offline_snapshot: 1
+        module_error: 1
+      when: dbquery_state_offline_snapshot.item[0].state.S == "Failed"
 
     - name: Scan if author primary instance is started
       dynamodb_search:
@@ -118,6 +186,23 @@
       with_items:
         "{{ cmd_start_author_primary.item }}"
 
+    - name: Query if starting Author Primary Service was successful
+      dynamodb_search:
+        table_name: "{{ dynamodb_tablename }}"
+        attribute: command_id
+        attribute_value: "{{ cmd_id_start_author_primary }}"
+        get_attribute: state
+        select: SPECIFIC_ATTRIBUTES
+        comparisonoperator: EQ
+        state: query
+      register: dbquery_state_start_author_primary
+
+    - name: Check for error when starting Author Primary Service
+      set_fact:
+        error_start_author_primary: 1
+        module_error: 1
+      when: dbquery_state_start_author_primary.item[0].state.S == "Failed"
+
     - name: Scan if author standby instance is started
       dynamodb_search:
         table_name: "{{ dynamodb_tablename }}"
@@ -136,6 +221,23 @@
         cmd_id_start_author_standby: "{{ item.command_id.S }}"
       with_items:
         "{{ cmd_start_author_standby.item }}"
+
+    - name: Query if starting Author Standby Service was successful
+      dynamodb_search:
+        table_name: "{{ dynamodb_tablename }}"
+        attribute: command_id
+        attribute_value: "{{ cmd_id_start_author_standby }}"
+        get_attribute: state
+        select: SPECIFIC_ATTRIBUTES
+        comparisonoperator: EQ
+        state: query
+      register: dbquery_state_start_author_standby
+
+    - name: Check for error when starting Author Standby Service
+      set_fact:
+        error_start_author_standby: 1
+        module_error: 1
+      when: dbquery_state_start_author_standby.item[0].state.S == "Failed"
 
     - name: Scan if publish instance is started
       dynamodb_search:
@@ -156,6 +258,23 @@
       with_items:
         "{{ cmd_start_publish.item }}"
 
+    - name: Query if starting Publish Services were successful
+      dynamodb_search:
+        table_name: "{{ dynamodb_tablename }}"
+        attribute: command_id
+        attribute_value: "{{ cmd_id_start_publish }}"
+        get_attribute: state
+        select: SPECIFIC_ATTRIBUTES
+        comparisonoperator: EQ
+        state: query
+      register: dbquery_state_start_publish
+
+    - name: Check for error when starting Publish Service
+      set_fact:
+        error_start_publish: 1
+        module_error: 1
+      when: dbquery_state_start_publish.item[0].state.S == "Failed"
+
     - name: Query if offline-snapshot was successful
       dynamodb_search:
         table_name: "{{ dynamodb_tablename }}"
@@ -171,88 +290,170 @@
       retries:  720
       delay: 5
 
-    - name: Get path to output files
+    - name: Check if offline-snapshot failed
+      set_fact:
+        general_error: 1
+      when: dbquery.item[0].state.S == "Failed"
+
+    - name: Get path to output files of stopping Author Standby Service
       aws_s3:
         mode: list
         bucket: "{{ s3.bucket }}"
         prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_stop_author_standby }}"
       register: output_files_stop_author_standby
+      When: cmd_id_stop_author_standby is defined
 
-    - name: Get path to output files
+    - name: Get path to output files of stopping Author Primary Service
       aws_s3:
         mode: list
         bucket: "{{ s3.bucket }}"
         prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_stop_author_primary }}"
       register: output_files_stop_author_primary
+      When: cmd_id_stop_author_primary is defined
 
-    - name: Get path to output files
+    - name: Get path to output files of stopping Publish Service
       aws_s3:
         mode: list
         bucket: "{{ s3.bucket }}"
         prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_stop_publish }}"
       register: output_files_stop_publish
+      When: cmd_id_stop_publish is defined
 
-    - name: Get path to output files
+    - name: Get path to output files of taking offline backup
       aws_s3:
         mode: list
         bucket: "{{ s3.bucket }}"
         prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_offline_backup }}"
       register: output_files_offline_backup
+      When: cmd_id_offline_backup is defined
 
-    - name: Get path to output files
+    - name: Get path to output files of starting Author Primary Service
       aws_s3:
         mode: list
         bucket: "{{ s3.bucket }}"
         prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_start_author_primary }}"
       register: output_files_start_author_primary
+      When: cmd_id_start_author_primary is defined
 
-    - name: Get path to output files
+    - name: Get path to output files of stopping Author Standby Service
       aws_s3:
         mode: list
         bucket: "{{ s3.bucket }}"
         prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_start_author_standby }}"
       register: output_files_start_author_standby
+      When: cmd_id_start_author_standby is defined
 
-    - name: Get path to output files
+    - name: Get path to output files of stopping Publish Service
       aws_s3:
         mode: list
         bucket: "{{ s3.bucket }}"
         prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_start_publish }}"
       register: output_files_start_publish
+      When: cmd_id_start_publish is defined
 
-    - name: Set facts for getting command output
+    - name: Set global facts for getting command output
       set_fact:
         log_path: "{{ playbook_dir }}/logs/"
-        dl_path_stop_author_standby: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_stop_author_standby }}"
-        dl_path_stop_author_primary: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_stop_author_primary }}"
-        dl_path_stop_publish: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_stop_publish }}"
-        dl_path_offline_backup: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_offline_backup }}"
-        dl_path_start_author_primary: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_start_author_primary }}"
-        dl_path_start_author_standby: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_start_author_standby }}"
-        dl_path_start_publish: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_start_publish }}"
-        s3_files_stop_author_standby: "{{ output_files_stop_author_standby.s3_keys }}"
-        s3_files_stop_author_primary: "{{ output_files_stop_author_primary.s3_keys }}"
-        s3_files_stop_publish: "{{ output_files_stop_publish.s3_keys }}"
-        s3_files_offline_backup: "{{ output_files_offline_backup.s3_keys }}"
-        s3_files_start_author_primary: "{{ output_files_start_author_primary.s3_keys }}"
-        s3_files_start_author_standby: "{{ output_files_start_author_standby.s3_keys }}"
-        s3_files_start_publish: "{{ output_files_start_publish.s3_keys }}"
 
-    - name: "Create Download directory"
+    - name: Set facts for getting command output of stopping Author Standby Service
+      set_fact:
+        dl_path_stop_author_standby: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_stop_author_standby }}"
+        s3_files_stop_author_standby: "{{ output_files_stop_author_standby.s3_keys }}"
+      when: error_stop_author_standby is defined or general_error is defined
+
+    - name: Set facts for getting command output of stopping Author Primary Service
+      set_fact:
+        dl_path_stop_author_primary: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_stop_author_primary }}"
+        s3_files_stop_author_primary: "{{ output_files_stop_author_primary.s3_keys }}"
+      when: error_stop_author_primary is defined or general_error is defined
+
+    - name: Set facts for getting command output of stopping Publish Services
+      set_fact:
+        dl_path_stop_publish: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_stop_publish }}"
+        s3_files_stop_publish: "{{ output_files_stop_publish.s3_keys }}"
+      when: error_stop_publish is defined or general_error is defined
+
+    - name: Set facts for getting command output of taking offline Backup
+      set_fact:
+        dl_path_offline_backup: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_offline_backup }}"
+        s3_files_offline_backup: "{{ output_files_offline_backup.s3_keys }}"
+      when: error_offline_snapshot is defined or general_error is defined
+
+    - name: Set facts for getting command output of starting Author Primary Service
+      set_fact:
+        dl_path_start_author_primary: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_start_author_primary }}"
+        s3_files_start_author_primary: "{{ output_files_start_author_primary.s3_keys }}"
+      when: error_start_author_primary is defined or general_error is defined
+
+    - name: Set facts for getting command output of starting Author Standby Service
+      set_fact:
+        dl_path_start_author_standby: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_start_author_standby }}"
+        s3_files_start_author_standby: "{{ output_files_start_author_standby.s3_keys }}"
+      when: error_start_author_standby is defined or general_error is defined
+
+    - name: Set facts for getting command output of starting Publish Services
+      set_fact:
+        dl_path_start_publish: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_start_publish }}"
+        s3_files_start_publish: "{{ output_files_start_publish.s3_keys }}"
+      when: error_start_publish is defined or general_error is defined
+
+    - name: "Create Download directory of stopping Author Standby Service"
       file:
         path: "{{ log_path }}{{ item|regex_replace('(stdout|stderr)$', '') }}"
         state: directory
       with_items:
         - "{{ s3_files_stop_author_standby }}"
-        - "{{ s3_files_stop_author_primary }}"
-        - "{{ s3_files_stop_author_standby }}"
-        - "{{ s3_files_stop_publish }}"
-        - "{{ s3_files_offline_backup }}"
-        - "{{ s3_files_start_author_primary }}"
-        - "{{ s3_files_start_author_standby }}"
-        - "{{ s3_files_start_publish }}"
+      when: error_stop_author_standby is defined or general_error is defined
 
-    - name: "Save command output to {{log_path }}"
+    - name: "Create Download directory of stopping Author Primary Service"
+      file:
+        path: "{{ log_path }}{{ item|regex_replace('(stdout|stderr)$', '') }}"
+        state: directory
+      with_items:
+        - "{{ s3_files_stop_author_primary }}"
+      when: error_stop_author_primary is defined or general_error is defined
+
+    - name: "Create Download directory of stopping Publish Service"
+      file:
+        path: "{{ log_path }}{{ item|regex_replace('(stdout|stderr)$', '') }}"
+        state: directory
+      with_items:
+        - "{{ s3_files_stop_publish }}"
+      when: error_stop_publish is defined or general_error is defined
+
+    - name: "Create Download directory of taking offline backup Service"
+      file:
+        path: "{{ log_path }}{{ item|regex_replace('(stdout|stderr)$', '') }}"
+        state: directory
+      with_items:
+      - "{{ s3_files_offline_backup }}"
+      when: error_offline_snapshot is defined or general_error is defined
+
+    - name: "Create Download directory of starting Author Primary Service"
+      file:
+        path: "{{ log_path }}{{ item|regex_replace('(stdout|stderr)$', '') }}"
+        state: directory
+      with_items:
+      - "{{ s3_files_start_author_primary }}"
+      when: error_start_author_primary is defined or general_error is defined
+
+    - name: "Create Download directory of starting Author Standby Service"
+      file:
+        path: "{{ log_path }}{{ item|regex_replace('(stdout|stderr)$', '') }}"
+        state: directory
+      with_items:
+      - "{{ s3_files_start_author_standby }}"
+      when: error_start_author_standby is defined or general_error is defined
+
+    - name: "Create Download directory of starting Publish Service"
+      file:
+        path: "{{ log_path }}{{ item|regex_replace('(stdout|stderr)$', '') }}"
+        state: directory
+      with_items:
+      - "{{ s3_files_start_publish }}"
+      when: error_start_publish is defined or general_error is defined
+
+    - name: "Save command output stopping Author Primary Service to {{log_path }}"
       aws_s3:
         mode: get
         bucket: "{{ s3.bucket }}"
@@ -260,78 +461,187 @@
         dest: "{{ log_path }}{{ item }}"
       with_items:
         - "{{ s3_files_stop_author_standby }}"
-        - "{{ s3_files_stop_author_primary }}"
-        - "{{ s3_files_stop_author_standby }}"
-        - "{{ s3_files_stop_publish }}"
-        - "{{ s3_files_offline_backup }}"
-        - "{{ s3_files_start_author_primary }}"
-        - "{{ s3_files_start_author_standby }}"
-        - "{{ s3_files_start_publish }}"
+      when: error_stop_author_standby is defined or general_error is defined
 
-    - name: "Find error log files in {{log_path }}{{dl_path_stop_author_standby}}"
+    - name: "Save command output stopping Author Standby Service to {{log_path }}"
+      aws_s3:
+        mode: get
+        bucket: "{{ s3.bucket }}"
+        object: "{{ item }}"
+        dest: "{{ log_path }}{{ item }}"
+      with_items:
+        - "{{ s3_files_stop_author_primary }}"
+      when: error_stop_author_primary is defined or general_error is defined
+
+    - name: "Save command output stopping Publish Service to {{log_path }}"
+      aws_s3:
+        mode: get
+        bucket: "{{ s3.bucket }}"
+        object: "{{ item }}"
+        dest: "{{ log_path }}{{ item }}"
+      with_items:
+        - "{{ s3_files_stop_publish }}"
+      when: error_stop_publish is defined or general_error is defined
+
+    - name: "Save command output taking offline backup to {{log_path }}"
+      aws_s3:
+        mode: get
+        bucket: "{{ s3.bucket }}"
+        object: "{{ item }}"
+        dest: "{{ log_path }}{{ item }}"
+      with_items:
+        - "{{ s3_files_offline_backup }}"
+      when: error_offline_snapshot is defined or general_error is defined
+
+    - name: "Save command output starting Author Primary Service to {{log_path }}"
+      aws_s3:
+        mode: get
+        bucket: "{{ s3.bucket }}"
+        object: "{{ item }}"
+        dest: "{{ log_path }}{{ item }}"
+      with_items:
+        - "{{ s3_files_start_author_primary }}"
+      when: error_start_author_primary is defined or general_error is defined
+
+    - name: "Save command output starting Author Standby Service to {{log_path }}"
+      aws_s3:
+        mode: get
+        bucket: "{{ s3.bucket }}"
+        object: "{{ item }}"
+        dest: "{{ log_path }}{{ item }}"
+      with_items:
+        - "{{ s3_files_start_author_standby }}"
+      when: error_start_author_standby is defined or general_error is defined
+
+    - name: "Save command output starting Publish Service to {{log_path }}"
+      aws_s3:
+        mode: get
+        bucket: "{{ s3.bucket }}"
+        object: "{{ item }}"
+        dest: "{{ log_path }}{{ item }}"
+      with_items:
+        - "{{ s3_files_start_publish }}"
+      when: error_start_publish is defined or general_error is defined
+
+    - name: "Find error log files of stopping Author Standby Service"
       find:
         paths: "{{log_path }}{{ dl_path_stop_author_standby }}"
         file_type: file
         patterns: stderr
         recurse: yes
       register: stderr_stop_author_standby
+      when: error_stop_author_standby is defined or general_error is defined
 
-    - name: "Find error log files in {{log_path }}{{dl_path_stop_author_primary}}"
+    - name: "Find error log files of stopping Author Primary Service"
       find:
         paths: "{{log_path }}{{ dl_path_stop_author_primary }}"
         file_type: file
         patterns: stderr
         recurse: yes
       register: stderr_stop_author_primary
+      when: error_stop_author_primary is defined or general_error is defined
 
-    - name: "Find error log files in {{log_path }}{{dl_path_stop_publish}}"
+    - name: "Find error log files of stopping Publish Service"
       find:
         paths: "{{log_path }}{{ dl_path_stop_publish }}"
         file_type: file
         patterns: stderr
         recurse: yes
       register: stderr_stop_publish
+      when: error_stop_publish is defined or general_error is defined
 
-    - name: "Find error log files in {{log_path }}{{dl_path_offline_backup}}"
+    - name: "Find error log files of taking offline backup"
       find:
         paths: "{{log_path }}{{ dl_path_offline_backup }}"
         file_type: file
         patterns: stderr
         recurse: yes
       register: stderr_offline_backup
+      when: error_offline_snapshot is defined or general_error is defined
 
-    - name: "Find error log files in {{log_path }}{{dl_path_start_author_primary}}"
+    - name: "Find error log files of starting Author Primary Service"
       find:
         paths: "{{log_path }}{{ dl_path_start_author_primary }}"
         file_type: file
         patterns: stderr
         recurse: yes
       register: stderr_start_author_primary
+      when: error_start_author_primary is defined or general_error is defined
 
-    - name: "Find error log files in {{log_path }}{{dl_path_start_author_standby}}"
+    - name: "Find error log files of starting Author Standby Service"
       find:
         paths: "{{log_path }}{{ dl_path_start_author_standby }}"
         file_type: file
         patterns: stderr
         recurse: yes
       register: stderr_start_author_standby
+      when: error_start_author_standby is defined or general_error is defined
 
-    - name: "Find error log files in {{log_path }}{{dl_path_start_author_standby}}"
+    - name: "Find error log files of starting Publish Service"
       find:
         paths: "{{log_path }}{{ dl_path_start_publish }}"
         file_type: file
         patterns: stderr
         recurse: yes
       register: stderr_path_start_publish
+      when: error_start_publish is defined or general_error is defined
 
-    - log_output:
+    - name: "Show Error Log of stopping Author Standby Service"
+      log_output:
         type: file
         log_files: "{{ item.files | map(attribute='path')|list }}"
       with_items:
         - "{{stderr_stop_author_standby}}"
+      when: error_stop_author_standby is defined or general_error is defined
+
+    - name: "Show Error Log of stopping Author Primary Service"
+      log_output:
+        type: file
+        log_files: "{{ item.files | map(attribute='path')|list }}"
+      with_items:
         - "{{stderr_stop_author_primary}}"
+      when: error_stop_author_primary is defined or general_error is defined
+
+    - name: "Show Error Log of stopping Publish Service"
+      log_output:
+        type: file
+        log_files: "{{ item.files | map(attribute='path')|list }}"
+      with_items:
         - "{{stderr_stop_publish}}"
+      when: error_stop_publish is defined or general_error is defined
+
+    - name: "Show Error Log of taking offline backup"
+      log_output:
+        type: file
+        log_files: "{{ item.files | map(attribute='path')|list }}"
+      with_items:
         - "{{stderr_offline_backup}}"
+      when: error_offline_snapshot is defined or general_error is defined
+
+    - name: "Show Error Log of starting Author Primary Service"
+      log_output:
+        type: file
+        log_files: "{{ item.files | map(attribute='path')|list }}"
+      with_items:
         - "{{stderr_start_author_primary}}"
+      when: error_start_author_primary is defined or general_error is defined
+
+    - name: "Show Error Log of starting Author Standby Service"
+      log_output:
+        type: file
+        log_files: "{{ item.files | map(attribute='path')|list }}"
+      with_items:
         - "{{stderr_start_author_standby}}"
+      when: error_start_author_standby is defined or general_error is defined
+
+    - name: "Show Error Log of starting Publish Service"
+      log_output:
+        type: file
+        log_files: "{{ item.files | map(attribute='path')|list }}"
+      with_items:
         - "{{stderr_path_start_publish}}"
+      when: error_start_publish is defined or general_error is defined
+
+    - fail:
+        msg: "Error while executing offline-snapshot"
+      when: general_error is defined or module_error is defined

--- a/offline-snapshot.yaml
+++ b/offline-snapshot.yaml
@@ -335,7 +335,7 @@
       register: output_files_start_author_primary
       When: cmd_id_start_author_primary is defined
 
-    - name: Get path to output files of stopping Author Standby Service
+    - name: Get path to output files of starting Author Standby Service
       aws_s3:
         mode: list
         bucket: "{{ s3.bucket }}"
@@ -343,7 +343,7 @@
       register: output_files_start_author_standby
       When: cmd_id_start_author_standby is defined
 
-    - name: Get path to output files of stopping Publish Service
+    - name: Get path to output files of starting Publish Service
       aws_s3:
         mode: list
         bucket: "{{ s3.bucket }}"
@@ -453,7 +453,7 @@
       - "{{ s3_files_start_publish }}"
       when: error_start_publish is defined or general_error is defined
 
-    - name: "Save command output stopping Author Primary Service to {{log_path }}"
+    - name: "Save command output stopping Author Standby Service to {{log_path }}"
       aws_s3:
         mode: get
         bucket: "{{ s3.bucket }}"
@@ -463,7 +463,7 @@
         - "{{ s3_files_stop_author_standby }}"
       when: error_stop_author_standby is defined or general_error is defined
 
-    - name: "Save command output stopping Author Standby Service to {{log_path }}"
+    - name: "Save command output stopping Author Primary Service to {{log_path }}"
       aws_s3:
         mode: get
         bucket: "{{ s3.bucket }}"

--- a/offline-snapshot.yaml
+++ b/offline-snapshot.yaml
@@ -301,7 +301,7 @@
         bucket: "{{ s3.bucket }}"
         prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_stop_author_standby }}"
       register: output_files_stop_author_standby
-      When: cmd_id_stop_author_standby is defined
+      when: cmd_id_stop_author_standby is defined
 
     - name: Get path to output files of stopping Author Primary Service
       aws_s3:
@@ -309,7 +309,7 @@
         bucket: "{{ s3.bucket }}"
         prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_stop_author_primary }}"
       register: output_files_stop_author_primary
-      When: cmd_id_stop_author_primary is defined
+      when: cmd_id_stop_author_primary is defined
 
     - name: Get path to output files of stopping Publish Service
       aws_s3:
@@ -317,7 +317,7 @@
         bucket: "{{ s3.bucket }}"
         prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_stop_publish }}"
       register: output_files_stop_publish
-      When: cmd_id_stop_publish is defined
+      when: cmd_id_stop_publish is defined
 
     - name: Get path to output files of taking offline backup
       aws_s3:
@@ -325,7 +325,7 @@
         bucket: "{{ s3.bucket }}"
         prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_offline_backup }}"
       register: output_files_offline_backup
-      When: cmd_id_offline_backup is defined
+      when: cmd_id_offline_backup is defined
 
     - name: Get path to output files of starting Author Primary Service
       aws_s3:
@@ -333,7 +333,7 @@
         bucket: "{{ s3.bucket }}"
         prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_start_author_primary }}"
       register: output_files_start_author_primary
-      When: cmd_id_start_author_primary is defined
+      when: cmd_id_start_author_primary is defined
 
     - name: Get path to output files of starting Author Standby Service
       aws_s3:
@@ -341,7 +341,7 @@
         bucket: "{{ s3.bucket }}"
         prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_start_author_standby }}"
       register: output_files_start_author_standby
-      When: cmd_id_start_author_standby is defined
+      when: cmd_id_start_author_standby is defined
 
     - name: Get path to output files of starting Publish Service
       aws_s3:
@@ -349,7 +349,7 @@
         bucket: "{{ s3.bucket }}"
         prefix: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id_start_publish }}"
       register: output_files_start_publish
-      When: cmd_id_start_publish is defined
+      when: cmd_id_start_publish is defined
 
     - name: Set global facts for getting command output
       set_fact:

--- a/send-message.yaml
+++ b/send-message.yaml
@@ -57,7 +57,12 @@
       retries: 120
       delay: 5
 
-    - name: Get path to output files
+    - name: Check if command execution failed
+      set_fact:
+        general_error: 1
+      when: dbquery.item[0].state.S == "Failed"
+
+    - name: "Get path to log files"
       aws_s3:
         mode: list
         bucket: "{{ s3.bucket }}"
@@ -69,8 +74,7 @@
         log_path: "{{ playbook_dir }}/logs/"
         dl_path: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id }}"
         s3_files: "{{ output_files.s3_keys }}"
-
-    - debug: msg="{{ s3_files }}"
+      When: cmd_id is defined
 
     - name: "Create Download directory in {{log_path }}{{ dl_path }}"
       file:
@@ -78,8 +82,9 @@
         state: directory
       with_items:
         - "{{ s3_files }}"
+      when: general_error is defined
 
-    - name: "Save command output to {{log_path }}{{ dl_path }}"
+    - name: "Save log files"
       aws_s3:
         mode: get
         bucket: "{{ s3.bucket }}"
@@ -88,15 +93,19 @@
       with_items:
         - "{{ s3_files }}"
       register: saved_files
+      when: general_error is defined
 
-    - name: "Find error log files in {{log_path }}{{ dl_path }}"
+    - name: "Find error log files"
       find:
         paths: "{{log_path }}{{ dl_path }}"
         file_type: file
         patterns: stderr
         recurse: yes
       register: stderr_files
+      when: general_error is defined
 
-    - log_output:
+    - name: "Show Error Log"
+      log_output:
         type: file
         log_files: "{{ stderr_files.files | map(attribute='path')|list }}"
+      when: general_error is defined

--- a/send-message.yaml
+++ b/send-message.yaml
@@ -74,7 +74,7 @@
         log_path: "{{ playbook_dir }}/logs/"
         dl_path: "{{ stackmanager_prefix }}/stack-manager/SSMOutput/{{ cmd_id }}"
         s3_files: "{{ output_files.s3_keys }}"
-      When: cmd_id is defined
+      when: cmd_id is defined
 
     - name: "Create Download directory in {{log_path }}{{ dl_path }}"
       file:


### PR DESCRIPTION
To increase the usability of the messenger I improved the error handling of the SSM command execution. 

The messenger now only print out Error logfiles if a command has the state 'Failed'.