### PR TITLE
Fixed error handling of offline snapshots

### DIFF
--- a/offline-compaction-snapshot.yaml
+++ b/offline-compaction-snapshot.yaml
@@ -15,6 +15,27 @@
     - debug:
         msg: "Send message: {{ message }} with subject: {{ subject }} to topic: {{ sns_topic }} in region: {{ aws_region }}"
 
+    - name: Query if Backup lock exist
+      dynamodb_search:
+        table_name: "{{ dynamodb_tablename }}"
+        attribute: command_id
+        attribute_value: "{{ stack_prefix }}_backup_lock"
+        get_attribute: command_id
+        select: SPECIFIC_ATTRIBUTES
+        comparisonoperator: EQ
+        state: query
+      register: dbquery_backup_lock
+
+    - name: Check if DB is locked
+      set_fact:
+        db_backup_locked: "{{dbquery_backup_lock.item[0].command_id.S}}"
+      when: "'item' in dbquery_backup_lock"
+
+    - name: Fail when DB is locked
+      fail:
+        msg: "Error: Another offline compaction backup is running"
+      when: db_backup_locked is defined
+
     - name: Send message to SNS Topic
       sns:
         msg: "{{ message }}"
@@ -53,11 +74,16 @@
         state: query
       register: dbquery_state_stop_author_standby
 
+    - name: Set fact for error check
+      set_fact:
+        dbquery_state_failed_stop_author_standby: "{{dbquery_state_stop_author_standby.item[0].state.S}}"
+      when: '"item" in dbquery_state_stop_author_standby'
+
     - name: Check for error when stopping Author Standby Service
       set_fact:
         error_stop_author_standby: 1
         module_error: 1
-      when: dbquery_state_stop_author_standby.item[0].state.S == "Failed"
+      when: dbquery_state_failed_stop_author_standby is defined and dbquery_state_failed_stop_author_standby == "Failed"
 
     - name: Scan if Author Primary Service is stopped
       dynamodb_search:
@@ -92,11 +118,16 @@
       register: dbquery_state_stop_author_primary
       when: module_error is undefined
 
+    - name: Set fact for error check
+      set_fact:
+        dbquery_state_failed_stop_author_primary: "{{dbquery_state_stop_author_primary.item[0].state.S}}"
+      when: '"item" in dbquery_state_stop_author_primary'
+
     - name: Check for error when stopping Author Primary Service
       set_fact:
         error_stop_author_primary: 1
         module_error: 1
-      when: dbquery_state_stop_author_primary.item[0].state.S == "Failed" and module_error is undefined
+      when: dbquery_state_failed_stop_author_primary is defined and dbquery_state_failed_stop_author_primary == "Failed" and module_error is undefined
 
     - name: Scan if Publish Services are stopped
       dynamodb_search:
@@ -131,11 +162,16 @@
       register: dbquery_state_stop_publish
       when: module_error is undefined
 
+    - name: Set fact for error check
+      set_fact:
+        dbquery_state_failed_stop_publish: "{{dbquery_state_stop_publish.item[0].state.S}}"
+      when: '"item" in dbquery_state_stop_publish'
+
     - name: Check for error when stopping Publish Service
       set_fact:
         error_stop_publish: 1
         module_error: 1
-      when: dbquery_state_stop_publish.item[0].state.S == "Failed" and module_error is undefined
+      when: dbquery_state_failed_stop_publish is defined and dbquery_state_failed_stop_publish == "Failed" and module_error is undefined
 
     - name: Scan if offline-compaction finished
       dynamodb_search:
@@ -170,11 +206,16 @@
       register: dbquery_state_offline_compaction
       when: module_error is undefined
 
+    - name: Set fact for error check
+      set_fact:
+        dbquery_state_failed_offline_compaction: "{{dbquery_state_offline_compaction.item[0].state.S}}"
+      when: '"item" in dbquery_state_offline_compaction'
+
     - name: Check for error when taking offline compaction
       set_fact:
         error_offline_compaction: 1
         module_error: 1
-      when: dbquery_state_offline_compaction.item[0].state.S == "Failed" and module_error is undefined
+      when: dbquery_state_failed_offline_compaction is defined and dbquery_state_failed_offline_compaction == "Failed" and module_error is undefined
 
     - name: Scan if offline-backup is executed
       dynamodb_search:
@@ -209,11 +250,16 @@
       register: dbquery_state_offline_snapshot
       when: module_error is undefined
 
+    - name: Set fact for error check
+      set_fact:
+        dbquery_state_failed_offline_snapshot: "{{dbquery_state_offline_snapshot.item[0].state.S}}"
+      when: '"item" in dbquery_state_offline_snapshot'
+
     - name: Check for error when taking offline backup
       set_fact:
         error_offline_snapshot: 1
         module_error: 1
-      when: dbquery_state_offline_snapshot.item[0].state.S == "Failed" and module_error is undefined
+      when: dbquery_state_failed_offline_snapshot is defined and dbquery_state_failed_offline_snapshot == "Failed" and module_error is undefined
 
     - name: Scan if Author Primary Service is started
       dynamodb_search:
@@ -248,11 +294,16 @@
       register: dbquery_state_start_author_primary
       when: module_error is undefined
 
+    - name: Set fact for error check
+      set_fact:
+        dbquery_state_failed_start_author_primary: "{{dbquery_state_start_author_primary.item[0].state.S}}"
+      when: '"item" in dbquery_state_start_author_primary'
+
     - name: Check for error when starting Author Primary Service
       set_fact:
         error_start_author_primary: 1
         module_error: 1
-      when: dbquery_state_start_author_primary.item[0].state.S == "Failed" and module_error is undefined
+      when: dbquery_state_failed_start_author_primary is defined and dbquery_state_failed_start_author_primary == "Failed" and module_error is undefined
 
     - name: Scan if author standby instance is started
       dynamodb_search:
@@ -287,11 +338,16 @@
       register: dbquery_state_start_author_standby
       when: module_error is undefined
 
-    - name: Check for error when starting Author Standby Service
+    - name: Set fact for error check
+      set_fact:
+        dbquery_state_failed_start_author_standby: "{{dbquery_state_start_author_standby.item[0].state.S}}"
+      when: '"item" in dbquery_state_start_author_standby'
+
+    - name: Check for error when starting Author Primary Service
       set_fact:
         error_start_author_standby: 1
         module_error: 1
-      when: dbquery_state_start_author_standby.item[0].state.S == "Failed" and module_error is undefined
+      when: dbquery_state_failed_start_author_standby is defined and dbquery_state_failed_start_author_standby == "Failed" and module_error is undefined
 
     - name: Scan if publish instance is started
       dynamodb_search:
@@ -326,11 +382,16 @@
       register: dbquery_state_start_publish
       when: module_error is undefined
 
-    - name: Check for error when starting Publish Service
+    - name: Set fact for error check
+      set_fact:
+        dbquery_state_failed_start_publish: "{{dbquery_state_start_publish.item[0].state.S}}"
+      when: '"item" in dbquery_state_start_publish'
+
+    - name: Check for error when starting Author Primary Service
       set_fact:
         error_start_publish: 1
         module_error: 1
-      when: dbquery_state_start_publish.item[0].state.S == "Failed" and module_error is undefined
+      when: dbquery_state_failed_start_publish is defined and dbquery_state_failed_start_publish == "Failed" and module_error is undefined
 
     - name: Scan if job remaining compact jobs are finished
       dynamodb_search:
@@ -365,11 +426,16 @@
       register: dbquery_remain_compact_jobs
       when: module_error is undefined
 
+    - name: Set fact for error check
+      set_fact:
+        dbquery_state_failed_remain_compact_jobs: "{{dbquery_remain_compact_jobs.item[0].state.S}}"
+      when: '"item" in dbquery_remain_compact_jobs'
+
     - name: Check for error when checking for remaining compact jobs
       set_fact:
         error_remain_compact_jobs: 1
         module_error: 1
-      when: dbquery_remain_compact_jobs.item[0].state.S == "Failed" and module_error is undefined
+      when: dbquery_state_failed_remain_compact_jobs is defined and dbquery_state_failed_remain_compact_jobs == "Failed" and module_error is undefined
 
     - name: Scan if remaining publish instances are stopped
       dynamodb_search:
@@ -404,11 +470,16 @@
       register: dbquery_stop_remain_publish
       when: module_error is undefined
 
-    - name: Check for error when stoppping remaining Publish Service
+    - name: Set fact for error check
+      set_fact:
+        dbquery_state_failed_stop_remain_publish: "{{dbquery_stop_remain_publish.item[0].state.S}}"
+      when: '"item" in dbquery_stop_remain_publish'
+
+    - name: Check for error when checking for remaining compact jobs
       set_fact:
         error_stop_remain_publish: 1
         module_error: 1
-      when: dbquery_stop_remain_publish.item[0].state.S == "Failed" and module_error is undefined
+      when: dbquery_state_failed_stop_remain_publish is defined and dbquery_state_failed_stop_remain_publish == "Failed" and module_error is undefined
 
     - name: Scan if remaining publish instances are compacted
       dynamodb_search:
@@ -443,11 +514,16 @@
       register: dbquery_compact_publish
       when: module_error is undefined
 
+    - name: Set fact for error check
+      set_fact:
+        dbquery_state_failed_compact_publish: "{{dbquery_compact_publish.item[0].state.S}}"
+      when: '"item" in dbquery_compact_publish'
+
     - name: Check for error when compact remaining Publisher
       set_fact:
         error_remain_compact_publish: 1
         module_error: 1
-      when: dbquery_compact_publish.item[0].state.S == "Failed" and module_error is undefined
+      when: dbquery_state_failed_compact_publish is defined and dbquery_state_failed_compact_publish == "Failed" and module_error is undefined
 
     - name: Scan if remaining publish instances are started
       dynamodb_search:
@@ -482,11 +558,16 @@
       register: dbquery_start_remain_publish
       when: module_error is undefined
 
+    - name: Set fact for error check
+      set_fact:
+        dbquery_state_failed_start_remain_publish: "{{dbquery_start_remain_publish.item[0].state.S}}"
+      when: '"item" in dbquery_start_remain_publish'
+
     - name: Check for error when starting remaining Publisher
       set_fact:
         error_start_remain_publish: 1
         module_error: 1
-      when: dbquery_start_remain_publish.item[0].state.S == "Failed" and module_error is undefined
+      when: dbquery_state_failed_start_remain_publish is defined and dbquery_state_failed_start_remain_publish == "Failed" and module_error is undefined
 
     - name: Query if offline-compaction-snapshot was successful
       dynamodb_search:
@@ -503,10 +584,15 @@
       delay: 5
       when: module_error is undefined
 
+    - name: Set fact for error check
+      set_fact:
+        dbquery_failed: "{{dbquery.item[0].state.S}}"
+      when: '"item" in dbquery'
+
     - name: Check if offline-compaction-snapshot failed
       set_fact:
         general_error: 1
-      when: dbquery.item[0].state.S == "Failed" and module_error is undefined
+      when: dbquery_failed is defined and dbquery_failed == "Failed" and module_error is undefined
 
     - name: Get path to output files of stopping Author Standby Service
       aws_s3:

--- a/offline-snapshot.yaml
+++ b/offline-snapshot.yaml
@@ -15,6 +15,27 @@
     - debug:
         msg: "Send message: {{ message }} with subject: {{ subject }} to topic: {{ sns_topic }} in region: {{ aws_region }}"
 
+    - name: Query if Backup lock exist
+      dynamodb_search:
+        table_name: "{{ dynamodb_tablename }}"
+        attribute: command_id
+        attribute_value: "{{ stack_prefix }}_backup_lock"
+        get_attribute: command_id
+        select: SPECIFIC_ATTRIBUTES
+        comparisonoperator: EQ
+        state: query
+      register: dbquery_backup_lock
+
+    - name: Check if DB is locked
+      set_fact:
+        db_backup_locked: "{{dbquery_backup_lock.item[0].command_id.S}}"
+      when: dbquery_backup_lock.item[0] is defined
+
+    - name: Fail when DB is locked
+      fail:
+        msg: "Error: Another offline snapshot backup is running"
+      when: db_backup_locked is defined
+
     - name: Send message to SNS Topic
       sns:
         msg: "{{ message }}"
@@ -53,11 +74,16 @@
         state: query
       register: dbquery_state_stop_author_standby
 
+    - name: Set fact for error check
+      set_fact:
+        dbquery_state_failed_stop_author_standby: "{{dbquery_state_stop_author_standby.item[0].state.S}}"
+      when: '"item" in dbquery_state_stop_author_standby'
+
     - name: Check for error when stopping Author Standby Service
       set_fact:
         error_stop_author_standby: 1
         module_error: 1
-      when: dbquery_state_stop_author_standby.item[0].state.S == "Failed"
+      when: dbquery_state_failed_stop_author_standby is defined and dbquery_state_failed_stop_author_standby == "Failed"
 
     - name: Scan if author primary instance is stopped
       dynamodb_search:
@@ -92,11 +118,16 @@
       register: dbquery_state_stop_author_primary
       when: module_error is undefined
 
+    - name: Set fact for error check
+      set_fact:
+        dbquery_state_failed_stop_author_primary: "{{dbquery_state_stop_author_primary.item[0].state.S}}"
+      when: '"item" in dbquery_state_stop_author_primary'
+
     - name: Check for error when stopping Author Primary Service
       set_fact:
         error_stop_author_primary: 1
         module_error: 1
-      when: dbquery_state_stop_author_primary.item[0].state.S == "Failed" and module_error is undefined
+      when: dbquery_state_failed_stop_author_primary is defined and dbquery_state_failed_stop_author_primary == "Failed" and module_error is undefined
 
     - name: Scan if publish instance is stopped
       dynamodb_search:
@@ -131,11 +162,16 @@
       register: dbquery_state_stop_publish
       when: module_error is undefined
 
+    - name: Set fact for error check
+      set_fact:
+        dbquery_state_failed_stop_publish: "{{dbquery_state_stop_publish.item[0].state.S}}"
+      when: '"item" in dbquery_state_stop_publish'
+
     - name: Check for error when stopping Publish Service
       set_fact:
         error_stop_publish: 1
         module_error: 1
-      when: dbquery_state_stop_publish.item[0].state.S == "Failed" and module_error is undefined
+      when: dbquery_state_failed_stop_publish is defined and dbquery_state_failed_stop_publish == "Failed" and module_error is undefined
 
     - name: Scan if offline-backup is executed
       dynamodb_search:
@@ -170,11 +206,16 @@
       register: dbquery_state_offline_snapshot
       when: module_error is undefined
 
+    - name: Set fact for error check
+      set_fact:
+        dbquery_state_failed_offline_snapshot: "{{dbquery_state_offline_snapshot.item[0].state.S}}"
+      when: '"item" in dbquery_state_offline_snapshot'
+
     - name: Check for error when taking offline backup
       set_fact:
         error_offline_snapshot: 1
         module_error: 1
-      when: dbquery_state_offline_snapshot.item[0].state.S == "Failed" and module_error is undefined
+      when: dbquery_state_failed_offline_snapshot is defined and dbquery_state_failed_offline_snapshot == "Failed" and module_error is undefined
 
     - name: Scan if author primary instance is started
       dynamodb_search:
@@ -209,11 +250,16 @@
       register: dbquery_state_start_author_primary
       when: module_error is undefined
 
+    - name: Set fact for error check
+      set_fact:
+        dbquery_state_failed_start_author_primary: "{{dbquery_state_start_author_primary.item[0].state.S}}"
+      when: '"item" in dbquery_state_start_author_primary'
+
     - name: Check for error when starting Author Primary Service
       set_fact:
         error_start_author_primary: 1
         module_error: 1
-      when: dbquery_state_start_author_primary.item[0].state.S == "Failed" and module_error is undefined
+      when: dbquery_state_failed_start_author_primary is defined and dbquery_state_failed_start_author_primary == "Failed" and module_error is undefined
 
     - name: Scan if author standby instance is started
       dynamodb_search:
@@ -248,11 +294,16 @@
       register: dbquery_state_start_author_standby
       when: module_error is undefined
 
-    - name: Check for error when starting Author Standby Service
+    - name: Set fact for error check
+      set_fact:
+        dbquery_state_failed_start_author_standby: "{{dbquery_state_start_author_standby.item[0].state.S}}"
+      when: '"item" in dbquery_state_start_author_standby'
+
+    - name: Check for error when starting Author Primary Service
       set_fact:
         error_start_author_standby: 1
         module_error: 1
-      when: dbquery_state_start_author_standby.item[0].state.S == "Failed" and module_error is undefined
+      when: dbquery_state_failed_start_author_standby is defined and dbquery_state_failed_start_author_standby == "Failed" and module_error is undefined
 
     - name: Scan if publish instance is started
       dynamodb_search:
@@ -287,11 +338,16 @@
       register: dbquery_state_start_publish
       when: module_error is undefined
 
-    - name: Check for error when starting Publish Service
+    - name: Set fact for error check
+      set_fact:
+        dbquery_state_failed_start_publish: "{{dbquery_state_start_publish.item[0].state.S}}"
+      when: '"item" in dbquery_state_start_publish'
+
+    - name: Check for error when starting Author Primary Service
       set_fact:
         error_start_publish: 1
         module_error: 1
-      when: dbquery_state_start_publish.item[0].state.S == "Failed" and module_error is undefined
+      when: dbquery_state_failed_start_publish is defined and bquery_state_failed_start_publish == "Failed" and module_error is undefined
 
     - name: Query if offline-snapshot was successful
       dynamodb_search:
@@ -309,10 +365,15 @@
       delay: 5
       when: module_error is undefined
 
+    - name: Set fact for error check
+      set_fact:
+        dbquery_failed: "{{dbquery.item[0].state.S}}"
+      when: "'item' in dbquery"
+
     - name: Check if offline-snapshot failed
       set_fact:
         general_error: 1
-      when: dbquery.item[0].state.S == "Failed" and module_error is undefined
+      when: dbquery_failed is defined and dbquery_failed == "Failed" and module_error is undefined
 
     - name: Get path to output files of stopping Author Standby Service
       aws_s3:


### PR DESCRIPTION
Fixed an error in the error handling logic.

The error conditional check checks if variable e.g.

dbquery_state_stop_author_standby.item[0].state.S

contains the string 'Failed' but this variable only exist, if a query was executed. Since a query only gets executed if no error occures this playbook fails when one error occures, as it's expecting list item named 'item'. To fix this I added a additional condition check if list item 'item' exist and then set a new variable with e.g. dbquery_state_stop_author_standby.item[0].state.S.


Regarding issue
https://github.com/shinesolutions/aem-stack-manager-messenger/issues/22