### PR TITLE
Improved conditional checks when querying/scanning the DynamoDB #77

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -2,4 +2,6 @@ extends: default
 
 rules:
   line-length:
-    max: 170
+    max: 300
+
+  truthy: disable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+- Improved conditional checks when querying/scanning the DynamoDB #77
+
 ## 2.8.0 - 2019-08-20
 ### Added
 - Add enable-saml and disable-saml

--- a/provisioners/ansible/playbooks/offline-compaction-snapshot-full-set.yaml
+++ b/provisioners/ansible/playbooks/offline-compaction-snapshot-full-set.yaml
@@ -63,6 +63,9 @@
         state: query
         region: "{{ aws.region }}"
       register: dbquery_backup_lock
+      until: dbquery_backup_lock is defined and dbquery_backup_lock.item is defined and dbquery_backup_lock.item != [] and dbquery_backup_lock.item[0].command_id is defined and dbquery_backup_lock.item[0].command_id.S is defined
+      retries: 720
+      delay: 5
 
     - name: Check if DB is locked
       set_fact:
@@ -111,7 +114,7 @@
         state: scan
         region: "{{ aws.region }}"
       register: cmd_stop_author_standby
-      until: cmd_stop_author_standby.item != []
+      until: cmd_stop_author_standby is defined and cmd_stop_author_standby.item is defined and cmd_stop_author_standby.item != [] and cmd_stop_author_standby.item[0].command_id is defined and cmd_stop_author_standby.item[0].command_id.S is defined
       retries: 720
       delay: 5
 
@@ -131,6 +134,9 @@
         state: query
         region: "{{ aws.region }}"
       register: dbquery_state_stop_author_standby
+      until: dbquery_state_stop_author_standby is defined and dbquery_state_stop_author_standby.item is defined and dbquery_state_stop_author_standby.item != [] and dbquery_state_stop_author_standby.item[0].state is defined and dbquery_state_stop_author_standby.item[0].state.S is defined
+      retries: 720
+      delay: 5
 
     - name: Set fact for error check
       set_fact:
@@ -154,7 +160,7 @@
         state: scan
         region: "{{ aws.region }}"
       register: cmd_stop_author_primary
-      until: cmd_stop_author_primary.item != []
+      until: cmd_stop_author_primary is defined and cmd_stop_author_primary.item is defined and cmd_stop_author_primary.item != [] and cmd_stop_author_primary.item[0].command_id is defined and cmd_stop_author_primary.item[0].command_id.S is defined
       retries: 720
       delay: 5
       when: module_error is undefined
@@ -176,6 +182,9 @@
         state: query
         region: "{{ aws.region }}"
       register: dbquery_state_stop_author_primary
+      until: dbquery_state_stop_author_primary is defined and dbquery_state_stop_author_primary.item is defined and dbquery_state_stop_author_primary.item != [] and dbquery_state_stop_author_primary.item[0].state is defined and dbquery_state_stop_author_primary.item[0].state.S is defined
+      retries: 720
+      delay: 5
       when: module_error is undefined
 
     - name: Set fact for error check
@@ -200,7 +209,7 @@
         state: scan
         region: "{{ aws.region }}"
       register: cmd_stop_publish
-      until: cmd_stop_publish.item != []
+      until: cmd_stop_publish is defined and cmd_stop_publish.item is defined and cmd_stop_publish.item != [] and cmd_stop_publish.item[0].command_id is defined and cmd_stop_publish.item[0].command_id.S is defined
       retries: 720
       delay: 5
       when: module_error is undefined
@@ -222,6 +231,9 @@
         state: query
         region: "{{ aws.region }}"
       register: dbquery_state_stop_publish
+      until: dbquery_state_stop_publish is defined and dbquery_state_stop_publish.item is defined and dbquery_state_stop_publish.item != [] and dbquery_state_stop_publish.item[0].state is defined and dbquery_state_stop_publish.item[0].state.S is defined
+      retries: 720
+      delay: 5
       when: module_error is undefined
 
     - name: Set fact for error check
@@ -246,7 +258,7 @@
         state: scan
         region: "{{ aws.region }}"
       register: cmd_offline_compaction
-      until: cmd_offline_compaction.item != []
+      until: cmd_offline_compaction is defined and cmd_offline_compaction.item is defined and cmd_offline_compaction.item != [] and cmd_offline_compaction.item[0].command_id is defined and cmd_offline_compaction.item[0].command_id.S is defined
       retries: 720
       delay: 5
       when: module_error is undefined
@@ -268,6 +280,9 @@
         state: query
         region: "{{ aws.region }}"
       register: dbquery_state_offline_compaction
+      until: dbquery_state_offline_compaction is defined and dbquery_state_offline_compaction.item is defined and dbquery_state_offline_compaction.item != [] and dbquery_state_offline_compaction.item[0].state is defined and dbquery_state_offline_compaction.item[0].state.S is defined
+      retries: 720
+      delay: 5
       when: module_error is undefined
 
     - name: Set fact for error check
@@ -292,7 +307,7 @@
         state: scan
         region: "{{ aws.region }}"
       register: cmd_offline_backup
-      until: cmd_offline_backup.item != []
+      until: cmd_offline_backup is defined and cmd_offline_backup.item is defined and cmd_offline_backup.item != [] and cmd_offline_backup.item[0].command_id is defined and cmd_offline_backup.item[0].command_id.S is defined
       retries: 720
       delay: 5
       when: module_error is undefined
@@ -314,6 +329,9 @@
         state: query
         region: "{{ aws.region }}"
       register: dbquery_state_offline_snapshot
+      until: dbquery_state_offline_snapshot is defined and dbquery_state_offline_snapshot.item is defined and dbquery_state_offline_snapshot.item != [] and dbquery_state_offline_snapshot.item[0].state is defined and dbquery_state_offline_snapshot.item[0].state.S is defined
+      retries: 720
+      delay: 5
       when: module_error is undefined
 
     - name: Set fact for error check
@@ -338,7 +356,7 @@
         state: scan
         region: "{{ aws.region }}"
       register: cmd_start_author_primary
-      until: cmd_start_author_primary.item != []
+      until: cmd_start_author_primary is defined and cmd_start_author_primary.item is defined and cmd_start_author_primary.item != [] and cmd_start_author_primary.item[0].command_id is defined and cmd_start_author_primary.item[0].command_id.S is defined
       retries: 720
       delay: 5
       when: module_error is undefined
@@ -360,6 +378,9 @@
         state: query
         region: "{{ aws.region }}"
       register: dbquery_state_start_author_primary
+      until: dbquery_state_start_author_primary is defined and dbquery_state_start_author_primary.item is defined and dbquery_state_start_author_primary.item != [] and dbquery_state_start_author_primary.item[0].state is defined and dbquery_state_start_author_primary.item[0].state.S is defined
+      retries: 720
+      delay: 5
       when: module_error is undefined
 
     - name: Set fact for error check
@@ -384,7 +405,7 @@
         state: scan
         region: "{{ aws.region }}"
       register: cmd_start_author_standby
-      until: cmd_start_author_standby.item != []
+      until: cmd_start_author_standby is defined and cmd_start_author_standby.item is defined and cmd_start_author_standby.item != [] and cmd_start_author_standby.item[0].command_id is defined and cmd_start_author_standby.item[0].command_id.S is defined
       retries: 720
       delay: 5
       when: module_error is undefined
@@ -406,6 +427,9 @@
         state: query
         region: "{{ aws.region }}"
       register: dbquery_state_start_author_standby
+      until: dbquery_state_start_author_standby is defined and dbquery_state_start_author_standby.item is defined and dbquery_state_start_author_standby.item != [] and dbquery_state_start_author_standby.item[0].state is defined and dbquery_state_start_author_standby.item[0].state.S is defined
+      retries: 720
+      delay: 5
       when: module_error is undefined
 
     - name: Set fact for error check
@@ -430,7 +454,7 @@
         state: scan
         region: "{{ aws.region }}"
       register: cmd_start_publish
-      until: cmd_start_publish.item != []
+      until: cmd_start_publish is defined and cmd_start_publish.item is defined and cmd_start_publish.item != [] and cmd_start_publish.item[0].command_id is defined and cmd_start_publish.item[0].command_id.S is defined
       retries: 720
       delay: 5
       when: module_error is undefined
@@ -452,6 +476,9 @@
         state: query
         region: "{{ aws.region }}"
       register: dbquery_state_start_publish
+      until: dbquery_state_start_publish is defined and dbquery_state_start_publish.item is defined and dbquery_state_start_publish.item != [] and dbquery_state_start_publish.item[0].state is defined and dbquery_state_start_publish.item[0].state.S is defined
+      retries: 720
+      delay: 5
       when: module_error is undefined
 
     - name: Set fact for error check
@@ -476,7 +503,7 @@
         state: scan
         region: "{{ aws.region }}"
       register: cmd_remain_compact_jobs
-      until: cmd_remain_compact_jobs.item != []
+      until: cmd_remain_compact_jobs is defined and cmd_remain_compact_jobs.item is defined and cmd_remain_compact_jobs.item != [] and cmd_remain_compact_jobs.item[0].command_id is defined and cmd_remain_compact_jobs.item[0].command_id.S is defined
       retries: 720
       delay: 5
       when: module_error is undefined
@@ -498,6 +525,9 @@
         state: query
         region: "{{ aws.region }}"
       register: dbquery_remain_compact_jobs
+      until: dbquery_remain_compact_jobs is defined and dbquery_remain_compact_jobs.item is defined and dbquery_remain_compact_jobs.item != [] and dbquery_remain_compact_jobs.item[0].state is defined and dbquery_remain_compact_jobs.item[0].state.S is defined
+      retries: 720
+      delay: 5
       when: module_error is undefined
 
     - name: Set fact for error check
@@ -522,7 +552,7 @@
         state: scan
         region: "{{ aws.region }}"
       register: cmd_stop_remain_publish
-      until: cmd_stop_remain_publish.item != []
+      until: cmd_stop_remain_publish is defined and cmd_stop_remain_publish.item is defined and cmd_stop_remain_publish.item != [] and cmd_stop_remain_publish.item[0].command_id is defined and cmd_stop_remain_publish.item[0].command_id.S is defined
       retries: 720
       delay: 5
       when: module_error is undefined
@@ -544,6 +574,9 @@
         state: query
         region: "{{ aws.region }}"
       register: dbquery_stop_remain_publish
+      until: dbquery_stop_remain_publish is defined and dbquery_stop_remain_publish.item is defined and dbquery_stop_remain_publish.item != [] and dbquery_stop_remain_publish.item[0].state is defined and dbquery_stop_remain_publish.item[0].state.S is defined
+      retries: 720
+      delay: 5
       when: module_error is undefined
 
     - name: Set fact for error check
@@ -568,7 +601,7 @@
         state: scan
         region: "{{ aws.region }}"
       register: cmd_compact_publish
-      until: cmd_compact_publish.item != []
+      until: cmd_compact_publish is defined and cmd_compact_publish.item is defined and cmd_compact_publish.item != [] and cmd_compact_publish.item[0].command_id is defined and cmd_compact_publish.item[0].command_id.S is defined
       retries: 720
       delay: 5
       when: module_error is undefined
@@ -590,6 +623,9 @@
         state: query
         region: "{{ aws.region }}"
       register: dbquery_compact_publish
+      until: dbquery_compact_publish is defined and dbquery_compact_publish.item is defined and dbquery_compact_publish.item != [] and dbquery_compact_publish.item[0].state is defined and dbquery_compact_publish.item[0].state.S is defined
+      retries: 720
+      delay: 5
       when: module_error is undefined
 
     - name: Set fact for error check
@@ -614,7 +650,7 @@
         state: scan
         region: "{{ aws.region }}"
       register: cmd_start_remain_publish
-      until: cmd_start_remain_publish.item != []
+      until: cmd_start_remain_publish is defined and cmd_start_remain_publish.item is defined and cmd_start_remain_publish.item != [] and cmd_start_remain_publish.item[0].command_id is defined and cmd_start_remain_publish.item[0].command_id.S is defined
       retries: 720
       delay: 5
       when: module_error is undefined
@@ -636,6 +672,9 @@
         state: query
         region: "{{ aws.region }}"
       register: dbquery_start_remain_publish
+      until: dbquery_start_remain_publish is defined and dbquery_start_remain_publish.item is defined and dbquery_start_remain_publish.item != [] and dbquery_start_remain_publish.item[0].state is defined and dbquery_start_remain_publish.item[0].state.S is defined
+      retries: 720
+      delay: 5
       when: module_error is undefined
 
     - name: Set fact for error check
@@ -660,7 +699,7 @@
         state: query
         region: "{{ aws.region }}"
       register: dbquery
-      until: dbquery.item[0].state.S == "Success" or dbquery.item[0].state.S == "Failed"
+      until: dbquery is defined and dbquery.item is defined and dbquery.item != [] and dbquery.item[0].state is defined and dbquery.item[0].state.S is defined and dbquery.item[0].state.S == "Success" or dbquery.item[0].state.S == "Failed"
       retries: 720
       delay: 5
       when: module_error is undefined

--- a/provisioners/ansible/playbooks/offline-compaction-snapshot-full-set.yaml
+++ b/provisioners/ansible/playbooks/offline-compaction-snapshot-full-set.yaml
@@ -63,7 +63,7 @@
         state: query
         region: "{{ aws.region }}"
       register: dbquery_backup_lock
-      until: dbquery_backup_lock is defined and dbquery_backup_lock.item is defined and dbquery_backup_lock.item != [] and dbquery_backup_lock.item[0].command_id is defined and dbquery_backup_lock.item[0].command_id.S is defined
+      until: dbquery_backup_lock is defined and dbquery_backup_lock.item is defined
       retries: 720
       delay: 5
 

--- a/provisioners/ansible/playbooks/offline-compaction-snapshot-full-set.yaml
+++ b/provisioners/ansible/playbooks/offline-compaction-snapshot-full-set.yaml
@@ -699,7 +699,7 @@
         state: query
         region: "{{ aws.region }}"
       register: dbquery
-      until: dbquery is defined and dbquery.item is defined and dbquery.item != [] and dbquery.item[0].state is defined and dbquery.item[0].state.S is defined and dbquery.item[0].state.S == "Success" or dbquery.item[0].state.S == "Failed"
+      until: dbquery is defined and dbquery.item is defined and dbquery.item != [] and dbquery.item[0].state is defined and dbquery.item[0].state.S is defined and dbquery.item[0].state.S in ["Success", "Failed"]
       retries: 720
       delay: 5
       when: module_error is undefined

--- a/provisioners/ansible/playbooks/offline-snapshot-full-set.yaml
+++ b/provisioners/ansible/playbooks/offline-snapshot-full-set.yaml
@@ -63,7 +63,7 @@
         state: query
         region: "{{ aws.region }}"
       register: dbquery_backup_lock
-      until: dbquery_backup_lock is defined and dbquery_backup_lock.item is defined and dbquery_backup_lock.item != [] and dbquery_backup_lock.item[0].command_id is defined and dbquery_backup_lock.item[0].command_id.S is defined
+      until: dbquery_backup_lock is defined and dbquery_backup_lock.item is defined
       retries: 720
       delay: 5
 

--- a/provisioners/ansible/playbooks/offline-snapshot-full-set.yaml
+++ b/provisioners/ansible/playbooks/offline-snapshot-full-set.yaml
@@ -454,7 +454,7 @@
         state: query
         region: "{{ aws.region }}"
       register: dbquery
-      until: dbquery is defined and dbquery.item is defined and dbquery.item != [] and dbquery.item[0].state is defined and dbquery.item[0].state.S is defined and dbquery.item[0].state.S == "Success" or dbquery.item[0].state.S == "Failed"
+      until: dbquery is defined and dbquery.item is defined and dbquery.item != [] and dbquery.item[0].state is defined and dbquery.item[0].state.S is defined and dbquery.item[0].state.S in ["Success", "Failed"]
       # The retry values should mirror the TTL of the ssm.send_command of the Lambda function.
       retries: 720
       delay: 5

--- a/provisioners/ansible/playbooks/offline-snapshot-full-set.yaml
+++ b/provisioners/ansible/playbooks/offline-snapshot-full-set.yaml
@@ -63,6 +63,9 @@
         state: query
         region: "{{ aws.region }}"
       register: dbquery_backup_lock
+      until: dbquery_backup_lock is defined and dbquery_backup_lock.item is defined and dbquery_backup_lock.item != [] and dbquery_backup_lock.item[0].command_id is defined and dbquery_backup_lock.item[0].command_id.S is defined
+      retries: 720
+      delay: 5
 
     - name: Check if DB is locked
       set_fact:
@@ -111,7 +114,7 @@
         state: scan
         region: "{{ aws.region }}"
       register: cmd_stop_author_standby
-      until: cmd_stop_author_standby.item != []
+      until: cmd_stop_author_standby is defined and cmd_stop_author_standby.item is defined and cmd_stop_author_standby.item != [] and cmd_stop_author_standby.item[0].command_id is defined and cmd_stop_author_standby.item[0].command_id.S is defined
       retries: 720
       delay: 5
 
@@ -131,6 +134,9 @@
         state: query
         region: "{{ aws.region }}"
       register: dbquery_state_stop_author_standby
+      until: dbquery_state_stop_author_standby is defined and dbquery_state_stop_author_standby.item is defined and dbquery_state_stop_author_standby.item != [] and dbquery_state_stop_author_standby.item[0].state is defined and dbquery_state_stop_author_standby.item[0].state.S is defined
+      retries: 720
+      delay: 5
 
     - name: Set fact for error check
       set_fact:
@@ -154,7 +160,7 @@
         state: scan
         region: "{{ aws.region }}"
       register: cmd_stop_author_primary
-      until: cmd_stop_author_primary.item != []
+      until: cmd_stop_author_primary is defined and cmd_stop_author_primary.item is defined and cmd_stop_author_primary.item != [] and cmd_stop_author_primary.item[0].command_id is defined and cmd_stop_author_primary.item[0].command_id.S is defined
       retries: 720
       delay: 5
       when: module_error is undefined
@@ -176,6 +182,9 @@
         state: query
         region: "{{ aws.region }}"
       register: dbquery_state_stop_author_primary
+      until: dbquery_state_stop_author_primary is defined and dbquery_state_stop_author_primary.item is defined and dbquery_state_stop_author_primary.item != [] and dbquery_state_stop_author_primary.item[0].state is defined and dbquery_state_stop_author_primary.item[0].state.S is defined
+      retries: 720
+      delay: 5
       when: module_error is undefined
 
     - name: Set fact for error check
@@ -200,7 +209,7 @@
         state: scan
         region: "{{ aws.region }}"
       register: cmd_stop_publish
-      until: cmd_stop_publish.item != []
+      until: cmd_stop_publish is defined and cmd_stop_publish.item is defined and cmd_stop_publish.item != [] and cmd_stop_publish.item[0].command_id is defined and cmd_stop_publish.item[0].command_id.S is defined
       retries: 720
       delay: 5
       when: module_error is undefined
@@ -222,6 +231,9 @@
         state: query
         region: "{{ aws.region }}"
       register: dbquery_state_stop_publish
+      until: dbquery_state_stop_publish is defined and dbquery_state_stop_publish.item is defined and dbquery_state_stop_publish.item != [] and dbquery_state_stop_publish.item[0].state is defined and dbquery_state_stop_publish.item[0].state.S is defined
+      retries: 720
+      delay: 5
       when: module_error is undefined
 
     - name: Set fact for error check
@@ -246,7 +258,7 @@
         state: scan
         region: "{{ aws.region }}"
       register: cmd_offline_backup
-      until: cmd_offline_backup.item != []
+      until: cmd_offline_backup is defined and cmd_offline_backup.item is defined and cmd_offline_backup.item != [] and cmd_offline_backup.item[0].command_id is defined and  cmd_offline_backup.item[0].command_id.S is defined
       retries: 720
       delay: 5
       when: module_error is undefined
@@ -268,6 +280,9 @@
         state: query
         region: "{{ aws.region }}"
       register: dbquery_state_offline_snapshot
+      until: dbquery_state_offline_snapshot is defined and dbquery_state_offline_snapshot.item is defined and dbquery_state_offline_snapshot.item != [] and dbquery_state_offline_snapshot.item[0].state is defined and  dbquery_state_offline_snapshot.item[0].state.S is defined
+      retries: 720
+      delay: 5
       when: module_error is undefined
 
     - name: Set fact for error check
@@ -281,7 +296,7 @@
         module_error: 1
       when: dbquery_state_failed_offline_snapshot is defined and dbquery_state_failed_offline_snapshot == "Failed" and module_error is undefined
 
-    - name: Scan if author primary instance is started
+    - name: Scan if Author Primary Service is started
       dynamodb_search:
         table_name: "{{ dynamodb_tablename }}"
         attribute: last_command
@@ -292,7 +307,7 @@
         state: scan
         region: "{{ aws.region }}"
       register: cmd_start_author_primary
-      until: cmd_start_author_primary.item != []
+      until: cmd_start_author_primary is defined and cmd_start_author_primary.item is defined and cmd_start_author_primary.item != [] and cmd_start_author_primary.item[0].command_id is defined and  cmd_start_author_primary.item[0].command_id.S is defined
       retries: 720
       delay: 5
       when: module_error is undefined
@@ -314,6 +329,9 @@
         state: query
         region: "{{ aws.region }}"
       register: dbquery_state_start_author_primary
+      until: dbquery_state_start_author_primary is defined and dbquery_state_start_author_primary.item is defined and dbquery_state_start_author_primary.item != [] and dbquery_state_start_author_primary.item[0].state is defined and  dbquery_state_start_author_primary.item[0].state.S is defined
+      retries: 720
+      delay: 5
       when: module_error is undefined
 
     - name: Set fact for error check
@@ -338,7 +356,7 @@
         state: scan
         region: "{{ aws.region }}"
       register: cmd_start_author_standby
-      until: cmd_start_author_standby.item != []
+      until: cmd_start_author_standby is defined and cmd_start_author_standby.item is defined and cmd_start_author_standby.item != [] and cmd_start_author_standby.item[0].command_id is defined and cmd_start_author_standby.item[0].command_id.S is defined
       retries: 720
       delay: 5
       when: module_error is undefined
@@ -360,6 +378,9 @@
         state: query
         region: "{{ aws.region }}"
       register: dbquery_state_start_author_standby
+      until: dbquery_state_start_author_standby is defined and dbquery_state_start_author_standby.item is defined and dbquery_state_start_author_standby.item != [] and dbquery_state_start_author_standby.item[0].state is defined and  dbquery_state_start_author_standby.item[0].state.S is defined
+      retries: 720
+      delay: 5
       when: module_error is undefined
 
     - name: Set fact for error check
@@ -384,7 +405,7 @@
         state: scan
         region: "{{ aws.region }}"
       register: cmd_start_publish
-      until: cmd_start_publish.item != []
+      until: cmd_start_publish is defined and cmd_start_publish.item is defined and cmd_start_publish.item != [] and cmd_start_publish.item[0].command_id is defined and cmd_start_publish.item[0].command_id.S is defined
       retries: 720
       delay: 5
       when: module_error is undefined
@@ -406,6 +427,9 @@
         state: query
         region: "{{ aws.region }}"
       register: dbquery_state_start_publish
+      until: dbquery_state_start_publish is defined and dbquery_state_start_publish.item is defined and dbquery_state_start_publish.item != [] and dbquery_state_start_publish.item[0].state is defined and  dbquery_state_start_publish.item[0].state.S is defined
+      retries: 720
+      delay: 5
       when: module_error is undefined
 
     - name: Set fact for error check
@@ -430,7 +454,7 @@
         state: query
         region: "{{ aws.region }}"
       register: dbquery
-      until: dbquery.item[0].state.S == "Success" or dbquery.item[0].state.S == "Failed"
+      until: dbquery is defined and dbquery.item is defined and dbquery.item != [] and dbquery.item[0].state is defined and dbquery.item[0].state.S is defined and dbquery.item[0].state.S == "Success" or dbquery.item[0].state.S == "Failed"
       # The retry values should mirror the TTL of the ssm.send_command of the Lambda function.
       retries: 720
       delay: 5

--- a/provisioners/ansible/playbooks/send-message.yaml
+++ b/provisioners/ansible/playbooks/send-message.yaml
@@ -89,7 +89,7 @@
         state: scan
         region: "{{ aws.region }}"
       register: dbscan
-      until: dbscan.item != [] and dbscan.item[0].state.S in ["Success", "Failed"]
+      until: dbscan is defined and dbscan.item is defined and dbscan.item != [] and dbscan.item[0].state is defined and dbscan.item[0].state.S is defined and dbscan.item[0].state.S in ["Success", "Failed"]
       retries: "{{ poll_timeout.check_command_execution.retries }}"
       delay: "{{ poll_timeout.check_command_execution.delay }}"
 
@@ -114,6 +114,9 @@
         state: scan
         region: "{{ aws.region }}"
       register: dbscan
+      until: dbscan is defined and dbscan.item is defined and dbscan.item != [] and dbscan.item[0].command_id is defined and dbscan.item[0].command_id.S is defined
+      retries: 720
+      delay: 5
 
     - set_fact:
         cmd_id: "{{ item.command_id.S }}"

--- a/provisioners/ansible/playbooks/send-message.yaml
+++ b/provisioners/ansible/playbooks/send-message.yaml
@@ -115,8 +115,8 @@
         region: "{{ aws.region }}"
       register: dbscan
       until: dbscan is defined and dbscan.item is defined and dbscan.item != [] and dbscan.item[0].command_id is defined and dbscan.item[0].command_id.S is defined
-      retries: 720
-      delay: 5
+      retries: "{{ poll_timeout.check_command_execution.retries }}"
+      delay: "{{ poll_timeout.check_command_execution.delay }}"
 
     - set_fact:
         cmd_id: "{{ item.command_id.S }}"


### PR DESCRIPTION
Extend until loops with more conditional checks so the task execution does not fail anymore if the DynamoDB query fails #77 