### PR TITLE
Replace ec2_instance_facts with  ec2_instance_info and change default python version 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Changed
+- Changed AWSCLI and Boto3 version to make them consistent with PIP 21.0.1
 
 ## 2.13.0 - 2021-02-11
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Changed AWSCLI and Boto3 version to make them consistent with PIP 21.0.1
 
+### Fixed
+- Fixed hosts to use python3 instead of python
+
 ## 2.13.0 - 2021-02-11
 ### Changed
 - Lock down pylint to 2.6.0

--- a/conf/ansible/inventory/hosts
+++ b/conf/ansible/inventory/hosts
@@ -1,2 +1,2 @@
 [default]
-127.0.0.1 ansible_python_interpreter=python
+127.0.0.1 ansible_python_interpreter=python3

--- a/provisioners/ansible/playbooks/offline-compaction-snapshot-full-set.yaml
+++ b/provisioners/ansible/playbooks/offline-compaction-snapshot-full-set.yaml
@@ -9,7 +9,7 @@
 
   tasks:
     - name: "Get facts for Target AEM Stack {{ target_aem_stack_prefix }}"
-      ec2_instance_facts:
+      ec2_instance_info:
         filters:
           "tag:StackPrefix": "{{ target_aem_stack_prefix }}"
         region: "{{ aws.region }}"

--- a/provisioners/ansible/playbooks/offline-snapshot-full-set.yaml
+++ b/provisioners/ansible/playbooks/offline-snapshot-full-set.yaml
@@ -9,7 +9,7 @@
 
   tasks:
     - name: "Get facts for Target AEM Stack {{ target_aem_stack_prefix }}"
-      ec2_instance_facts:
+      ec2_instance_info:
         filters:
           "tag:StackPrefix": "{{ target_aem_stack_prefix }}"
         region: "{{ aws.region }}"

--- a/provisioners/ansible/playbooks/send-message.yaml
+++ b/provisioners/ansible/playbooks/send-message.yaml
@@ -9,7 +9,7 @@
 
   tasks:
     - name: "Get facts for Target AEM Stack {{ target_aem_stack_prefix }}"
-      ec2_instance_facts:
+      ec2_instance_info:
         filters:
           "tag:StackPrefix": "{{ target_aem_stack_prefix }}"
         region: "{{ aws.region }}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ansible==2.9.2
-awscli==1.16.304
-boto3==1.10.41
+awscli==1.19.8
+boto3==1.17.8
 pylint==2.6.0
 yamllint==1.19.0


### PR DESCRIPTION
Below changes are done: 
* Old Ansible module was "ec2_instance_facts" was deprecate due to security vulnerability
* Fix pip module to use  python3 instead of python2.
